### PR TITLE
Fixed the problem with showing double scroll on Book page.

### DIFF
--- a/client/src/Book.tsx
+++ b/client/src/Book.tsx
@@ -51,7 +51,8 @@ export class Book extends React.Component<BookProps, BookState> {
               id={parentID}
               style={{
                 position: 'relative',
-                height: '100%'
+                height: '100%',
+                overflow: 'hidden'
               }}
             >
               <iframe src={this.state.config.microsoftBookingsUrl} scrolling="yes" style={embededIframeStyles}></iframe>


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
- Removed the outer scroll by add `overflow: 'hidden'`. style attribute in `<LayerHost>` component.
**Before**
![image](https://user-images.githubusercontent.com/94404633/162497351-bf3f0f50-5f2f-41ae-be1e-f0ec8369c7c9.png)
**After**
![image](https://user-images.githubusercontent.com/94404633/162497432-5014fae5-a319-4857-9dc5-99be21a533c9.png)


# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
- Originally shows two scrolls on Book page. 
- Found [this](https://stackoverflow.com/questions/12989931/body-height-100-displaying-vertical-scrollbar) Stackoverflow and seem we are having similar issue.
# How Tested
<!--- How did you test your change. What tests have you added. -->
- Simply start the application and try with different screen size.
# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->