### PR TITLE
Centralize fake timers for UTs in TestUtils file

### DIFF
--- a/client/src/Book.test.tsx
+++ b/client/src/Book.test.tsx
@@ -8,7 +8,7 @@ import { Book } from './Book';
 import { Header } from './Header';
 import { AppConfigModel } from './models/ConfigModel';
 import { fetchConfig } from './utils/FetchConfig';
-import { fakeTimers } from './utils/TestUtils';
+import { runFakeTimers } from './utils/TestUtils';
 import { generateTheme } from './utils/ThemeGenerator';
 
 configure({ adapter: new Adapter() });
@@ -35,7 +35,7 @@ describe('Book', () => {
 
     const book = await mount(<Book />);
 
-    await fakeTimers();
+    await runFakeTimers();
 
     book.update();
 
@@ -55,7 +55,7 @@ describe('Book', () => {
 
     const book = await mount(<Book />);
 
-    await fakeTimers();
+    await runFakeTimers();
 
     book.update();
 
@@ -83,7 +83,7 @@ describe('Book', () => {
 
     const book = await mount(<Book />);
 
-    await fakeTimers();
+    await runFakeTimers();
 
     book.update();
 

--- a/client/src/Visit.test.tsx
+++ b/client/src/Visit.test.tsx
@@ -12,7 +12,7 @@ import { JoinTeamsMeeting } from './components/JoinTeamsMeeting';
 import { MeetingExperience } from './components/MeetingExperience';
 import { fetchConfig } from './utils/FetchConfig';
 import { getTeamsMeetingLink } from './utils/GetTeamsMeetingLink';
-import { fakeTimers } from './utils/TestUtils';
+import { runFakeTimers } from './utils/TestUtils';
 import { generateTheme } from './utils/ThemeGenerator';
 
 const MOCK_VALID_TEAMSMEETINGLINKMODEL = getTeamsMeetingLink(
@@ -62,7 +62,7 @@ describe('Visit', () => {
 
     const visit = await mount(<Visit />);
 
-    await fakeTimers();
+    await runFakeTimers();
 
     visit.update();
 
@@ -82,7 +82,7 @@ describe('Visit', () => {
 
     const visit = await mount(<Visit />);
 
-    await fakeTimers();
+    await runFakeTimers();
 
     visit.update();
 
@@ -110,7 +110,7 @@ describe('Visit', () => {
 
     const visit = await mount(<Visit />);
 
-    await fakeTimers();
+    await runFakeTimers();
 
     await visit.update();
 
@@ -144,7 +144,7 @@ describe('Visit', () => {
 
     visit.setState({ meetingLinkModel: MOCK_VALID_TEAMSMEETINGLINKMODEL });
 
-    await fakeTimers();
+    await runFakeTimers();
 
     await visit.update();
 

--- a/client/src/WaffleMenu.test.tsx
+++ b/client/src/WaffleMenu.test.tsx
@@ -6,7 +6,7 @@ import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import * as renderer from 'react-test-renderer';
 import { WaffleMenu, WaffleNavigation } from './WaffleMenu';
-import { fakeTimers } from './utils/TestUtils';
+import { runFakeTimers } from './utils/TestUtils';
 
 configure({ adapter: new Adapter() });
 
@@ -35,7 +35,7 @@ describe('WaffleMenu', () => {
 
     menuIcon.simulate('click');
 
-    await fakeTimers();
+    await runFakeTimers();
 
     waffleMenu.update();
 

--- a/client/src/utils/TestUtils.ts
+++ b/client/src/utils/TestUtils.ts
@@ -3,7 +3,7 @@
 
 import { act } from '@testing-library/react';
 
-export const fakeTimers = async (): Promise<void> => {
+export const runFakeTimers = async (): Promise<void> => {
   await act(async () => {
     jest.useFakeTimers();
     jest.runAllTimers();


### PR DESCRIPTION
# What
centralized calls of 
![image](https://user-images.githubusercontent.com/82416644/164560717-951a51e9-4c94-46c1-b957-5908441337c3.png)
in common file TestUtils
  

# Why
This was used multiple time and might be used in other UTs in the future, so centralizing will avoid copy/paste

# How Tested
Ran UTs locally and checked they all passed
![image](https://user-images.githubusercontent.com/82416644/164560950-073c0631-547c-4697-b60b-96fc512efeae.png)

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->