### PR TITLE
Fix UK data location in ARM Templates and add Norway, Switzerland, UAE

### DIFF
--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -25,7 +25,10 @@
         "India",
         "Japan",
         "Korea",
-        "United Kingdom",
+        "Norway",
+        "Switzerland",
+        "UAE",
+        "UK",
         "United States"
       ],
       "defaultValue": "United States",

--- a/deploy/editableazuredeploy.json
+++ b/deploy/editableazuredeploy.json
@@ -25,7 +25,10 @@
         "India",
         "Japan",
         "Korea",
-        "United Kingdom",
+        "Norway",
+        "Switzerland",
+        "UAE",
+        "UK",
         "United States"
       ],
       "defaultValue": "United States",


### PR DESCRIPTION
# What
ARM template deployment fails because of incorrect data location string for UK. Also, new locations have been added: Norway, Switzerland, UAE
![error-invalid-data-location](https://user-images.githubusercontent.com/43504546/168380238-f5270e45-78e9-4d8b-95e5-adce44818bbb.png)

# Why
To be able to select the data locations mentioned above.

# How Tested
Deployed to each of the regions:


![rgabrinao-uk](https://user-images.githubusercontent.com/43504546/168380474-72c49279-db12-4950-a736-fc1917d2b6d9.png)


![rgabrinao-norway](https://user-images.githubusercontent.com/43504546/168380490-ef988c50-fa95-46c3-9c71-555883d81a3a.png)

![rgabrinao-sw](https://user-images.githubusercontent.com/43504546/168380501-ec4863ca-882e-488b-bbd2-b1d3bb036450.png)

![rgabrinao-uae](https://user-images.githubusercontent.com/43504546/168380514-72c8c9c0-47e9-4092-bc5c-5c7649e1fc6f.png)






# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->