### PR TITLE
ARM template bug fix / apiVersion correction.

### DIFF
--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -60,7 +60,7 @@
     {
       "name": "[parameters('communicationServiceName')]",
       "type": "Microsoft.Communication/communicationServices",
-      "apiVersion": "2020-08-20-preview",
+      "apiVersion": "2020-08-20",
       "location": "global",
       "tags": {},
       "properties": {
@@ -93,7 +93,7 @@
         {
           "name": "appsettings",
           "type": "config",
-          "apiVersion": "2018-11-01",
+          "apiVersion": "2021-03-01",
           "dependsOn": [
             "[resourceId('Microsoft.Web/sites', parameters('appServiceName'))]"
           ],
@@ -101,7 +101,7 @@
             "displayName": "appsettings"
           },
           "properties": {
-            "VV_COMMUNICATION_SERVICES_CONNECTION_STRING": "[listkeys(resourceId('Microsoft.Communication/communicationServices', parameters('communicationServiceName')), '2020-08-20-preview' ).primaryConnectionString]",
+            "VV_COMMUNICATION_SERVICES_CONNECTION_STRING": "[listkeys(resourceId('Microsoft.Communication/communicationServices', parameters('communicationServiceName')), '2020-08-20').primaryConnectionString]",
             "WEBSITE_NODE_DEFAULT_VERSION": "12.21.0",
             "VV_MICROSOFT_BOOKINGS_URL": "[variables('microsoftBookingsUrl')]",
             "VV_CHAT_ENABLED": "[variables('chatEnabled')]",
@@ -117,7 +117,7 @@
           "name": "MSDeploy",
           "type": "extensions",
           "location": "[resourceGroup().location]",
-          "apiVersion": "2015-08-01",
+          "apiVersion": "2021-03-01",
           "dependsOn": [
             "[resourceId('Microsoft.Web/sites', parameters('appServiceName'))]",
             "[resourceId('Microsoft.Web/sites/config', parameters('appServiceName'), 'appsettings')]"

--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -98,7 +98,7 @@
             "displayName": "appsettings"
           },
           "properties": {
-            "VV_COMMUNICATION_SERVICES_CONNECTION_STRING": "[listkeys(parameters('communicationServiceName'), '2020-08-20-preview' ).primaryConnectionString]",
+            "VV_COMMUNICATION_SERVICES_CONNECTION_STRING": "[listkeys(resourceId('Microsoft.Communication/communicationServices', parameters('communicationServiceName')), '2020-08-20-preview' ).primaryConnectionString]",
             "WEBSITE_NODE_DEFAULT_VERSION": "12.21.0",
             "VV_MICROSOFT_BOOKINGS_URL": "[variables('microsoftBookingsUrl')]",
             "VV_CHAT_ENABLED": "[variables('chatEnabled')]",

--- a/deploy/azuredeployexistingresource.json
+++ b/deploy/azuredeployexistingresource.json
@@ -55,7 +55,7 @@
           {
             "name": "appsettings",
             "type": "config",
-            "apiVersion": "2018-11-01",
+            "apiVersion": "2021-03-01",
             "dependsOn": [
               "[resourceId('Microsoft.Web/sites', parameters('appServiceName'))]"
             ],
@@ -63,7 +63,7 @@
               "displayName": "appsettings"
             },
             "properties": {
-              "VV_COMMUNICATION_SERVICES_CONNECTION_STRING": "[listkeys(variables('resourceId'), '2020-08-20-preview' ).primaryConnectionString]",
+              "VV_COMMUNICATION_SERVICES_CONNECTION_STRING": "[listkeys(variables('resourceId'), '2020-08-20').primaryConnectionString]",
               "WEBSITE_NODE_DEFAULT_VERSION": "12.21.0",
               "VV_MICROSOFT_BOOKINGS_URL": "[variables('microsoftBookingsUrl')]",
               "VV_CHAT_ENABLED": "[variables('chatEnabled')]",
@@ -79,7 +79,7 @@
             "name": "MSDeploy",
             "type": "extensions",
             "location": "[resourceGroup().location]",
-            "apiVersion": "2015-08-01",
+            "apiVersion": "2021-03-01",
             "dependsOn": [
               "[resourceId('Microsoft.Web/sites', parameters('appServiceName'))]",
               "[resourceId('Microsoft.Web/sites/config', parameters('appServiceName'), 'appsettings')]"

--- a/deploy/editableazuredeploy.json
+++ b/deploy/editableazuredeploy.json
@@ -84,7 +84,7 @@
     {
       "name": "[parameters('communicationServiceName')]",
       "type": "Microsoft.Communication/communicationServices",
-      "apiVersion": "2020-08-20-preview",
+      "apiVersion": "2020-08-20",
       "location": "global",
       "tags": {},
       "properties": {
@@ -117,7 +117,7 @@
         {
           "name": "appsettings",
           "type": "config",
-          "apiVersion": "2018-11-01",
+          "apiVersion": "2021-03-01",
           "dependsOn": [
             "[resourceId('Microsoft.Web/sites', parameters('appServiceName'))]"
           ],
@@ -125,7 +125,7 @@
             "displayName": "appsettings"
           },
           "properties": {
-            "VV_COMMUNICATION_SERVICES_CONNECTION_STRING": "[listkeys(parameters('communicationServiceName'), '2020-08-20-preview' ).primaryConnectionString]",
+            "VV_COMMUNICATION_SERVICES_CONNECTION_STRING": "[listkeys(resourceId('Microsoft.Communication/communicationServices', parameters('communicationServiceName')), '2020-08-20').primaryConnectionString]",
             "WEBSITE_NODE_DEFAULT_VERSION": "12.21.0",
             "VV_MICROSOFT_BOOKINGS_URL": "[parameters('microsoftBookingsUrl')]",
             "VV_CHAT_ENABLED": "[parameters('chatEnabled')]",
@@ -141,7 +141,7 @@
           "name": "MSDeploy",
           "type": "extensions",
           "location": "[resourceGroup().location]",
-          "apiVersion": "2015-08-01",
+          "apiVersion": "2021-03-01",
           "dependsOn": [
             "[resourceId('Microsoft.Web/sites', parameters('appServiceName'))]",
             "[resourceId('Microsoft.Web/sites/config', parameters('appServiceName'), 'appsettings')]"


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
- Updated `resourceIdentifier` for `listkeys` function to use correct resource.
- We previously used old `apiVersion` that will get deprecates soon.

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
> This PR includes two changes.
- You can't have duplicate name on `App Service Name` and `Communication Service Name` fields.
  - `listkeys` function now return one result that what communication resource to use.
- Updated all `apiVersions` based on the test result from [Azure Resource Manager Template Toolkit](https://github.com/Azure/arm-ttk).
  > There are other errors remains.

# How Tested
<!--- How did you test your change. What tests have you added. -->
> **Important**
> When you following below steps, please use your person account that connected with your MS account.
1. You can go to [Custom Deployment](https://portal.azure.com/#create/Microsoft.Template) and select **"Build your own template in the editor"** as below.
![image](https://user-images.githubusercontent.com/94404633/168909688-1421950d-01c0-496e-b24e-71ae19712ddd.png)

2. In **"Edit template"** page, press **"Load file"** and upload `azuredeploy.json` from `/deploy/azuredeploy.json`.
![image](https://user-images.githubusercontent.com/94404633/168910149-dffe0a49-b336-4442-bac9-ea7cb603cc8d.png)

3. Once you click **"Save"** button on bottom left, it will redirect you to **"Custom deployment" page and you can see different input fields. You can select resource group and put the same name for **"App Service Name"** and **"Communication Service Name"** as below.
![image](https://user-images.githubusercontent.com/94404633/168910629-047781d7-f67b-49a7-835c-ffca72e79faa.png)

3. Once you complete the form, press **"Review + create"** button on bottom left, then it will go to next page and validate your input fields. Once you see the result as screenshots below, press **"Create"** button on bottom left then wait to be done.
![image](https://user-images.githubusercontent.com/94404633/168910881-d67a295b-8984-46ca-8fad-1542be3e7b40.png)
![image](https://user-images.githubusercontent.com/94404633/168910958-5de7ea4f-b0e8-4967-a73c-d302781bf229.png)

4. Once deployment completed, go to resource group to check if it creates two resources as below.
![image](https://user-images.githubusercontent.com/94404633/168911720-1a97178b-1894-4733-8b62-fd47d25bf7b7.png)
If you can see **"App Service"** and "**Communication Service"** as below, it worked!
![image](https://user-images.githubusercontent.com/94404633/168911816-a11f52fd-e322-4cb8-8176-1ecaa67fd1c8.png)


# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->