### PR TITLE
Update Node instructions to 14.19.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,10 @@ jobs:
           fetch-depth: 0
 
       # Ensure node version is great enough
-      - name: Use Node.js v14.x
-        uses: actions/setup-node@v1
+      - name: Use Node.js v14.19.x
+        uses: actions/setup-node@v3
         with:
-          node-version: "14.x"
+          node-version: "14.19.x"
 
       # Install client dependencies
       - name: Install client dependencies
@@ -67,10 +67,10 @@ jobs:
           fetch-depth: 0
 
       # Ensure node version is great enough
-      - name: Use Node.js v14.x
-        uses: actions/setup-node@v1
+      - name: Use Node.js v14.19.x
+        uses: actions/setup-node@v3
         with:
-          node-version: "14.x"
+          node-version: "14.19.x"
 
       # Install server dependencies
       - name: Install server dependencies

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -41,10 +41,10 @@ jobs:
         run: git checkout ${{ github.event.inputs.branch }}
 
       # Ensure node version is great enough
-      - name: Use Node.js v14.x
-        uses: actions/setup-node@v1
+      - name: Use Node.js v14.19.x
+        uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: "14.19.x"
 
       # Increment versions
       - name: Increment versions

--- a/.github/workflows/publish-nightly-build.yml
+++ b/.github/workflows/publish-nightly-build.yml
@@ -57,10 +57,10 @@ jobs:
     if: needs.checkForChanges.outputs.hasChanged == 'true'
     runs-on: ubuntu-latest
     steps:
-      - name: Install Node.js v14.x
-        uses: actions/setup-node@v1
+      - name: Install Node.js v14.19.x
+        uses: actions/setup-node@v3
         with:
-          node-version: "14.x"
+          node-version: "14.19.x"
 
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/publish-release-artifacts.yml
+++ b/.github/workflows/publish-release-artifacts.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     name: Publish Release
     steps:
-      - name: Install Node.js v14.x
-        uses: actions/setup-node@v1
+      - name: Use Node.js v14.19.x
+        uses: actions/setup-node@v3
         with:
-          node-version: "14.x"
+          node-version: "14.19.x"
 
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ There are two ways to start using this app:
 
 - Create an Azure account with an active subscription. For details, see [Create an account for free](https://azure.microsoft.com/free/).
 - An active Communication Services resource. [Create a Communication Services resource](https://docs.microsoft.com/azure/communication-services/quickstarts/create-communication-resource).
-- [Node.js (12.18.4 and above)](https://nodejs.org/en/download/)
+- [Node.js (14.19.0 and above)](https://nodejs.org/en/download/)
 
 ### Install Dependencies
 


### PR DESCRIPTION
# What
Match UI Library recommendation of using 14.19.x:
- https://github.com/Azure/communication-ui-library/pull/1488
- https://github.com/Azure/communication-ui-library/tree/main/samples/CallWithChat

# Why
Node 12 has been taken out and we want to make sure our customers are using a version of Node that we can get support on as well.

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->