### PR TITLE
Bug 2865505 Sample: ARM Templates are targeting 'latest' version of Sample in packageURL

### DIFF
--- a/.github/workflows/publish-nightly-build.yml
+++ b/.github/workflows/publish-nightly-build.yml
@@ -12,7 +12,7 @@ on:
     # minute 0, hour 23 UTC (which is 3pm PST/4pm PDT), any day of month, any month, any day of the week
     # if we want to support only Mon - Fri we need to change the check how we look for new changes. Currently we
     # check for any new changes in the last 24 hours regardless of day)
-    - cron: '0 23 * * *'
+    - cron: "0 23 * * *"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -82,7 +82,7 @@ jobs:
           newVersion=$(echo $clientVer | grep -oP "^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)")-nightly-${{ steps.datetime.outputs.datetime }}.0
           echo newversion: $newVersion
           echo "::set-output name=newProjectVersion::$newVersion"
-      
+
       # Increment versions in package.json
       - name: Increment versions
         run: node scripts/increment-version.js ${{ steps.version.outputs.newProjectVersion }}
@@ -90,6 +90,9 @@ jobs:
       # Update telemetry version
       - name: Synchronize package version reported to telemetry
         run: node scripts/sync-telemetry-package-version.js
+
+      - name: Update packageUrl in ARM templates
+        run: node scripts/set-arm-package-url.js Nightly/${{ steps.datetime.outputs.datetime }}
 
       - name: Create source archive
         run: zip -r sample-source.zip . -x *.git*

--- a/.github/workflows/publish-release-artifacts.yml
+++ b/.github/workflows/publish-release-artifacts.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       release-flavor:
-        description: 'Beta release or stable release.'
+        description: "Beta release or stable release."
         required: true
         type: choice
         options:
@@ -36,6 +36,9 @@ jobs:
           echo serverversion: $serverVer
           if [ $clientVer != $serverVer ]; then (echo "client and server versions do not match"; exit 1;); fi
           echo "::set-output name=newProjectVersion::$clientVer"
+
+      - name: Update packageUrl in ARM templates
+        run: node scripts/set-arm-package-url.js Release/${{ steps.version.outputs.newProjectVersion }}
 
       # Create zipped version of the repository
       - name: Create source archive

--- a/scripts/set-arm-package-url.js
+++ b/scripts/set-arm-package-url.js
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const ROOT = path.join(__dirname, "..");
+const DEPLOY_DIR = path.join(ROOT, "deploy");
+const AZURE_DEPLOY = path.join(DEPLOY_DIR, "azuredeploy.json");
+const AZURE_DEPLOY_EXISTING = path.join(
+  DEPLOY_DIR,
+  "azuredeployexistingresource.json"
+);
+const AZURE_DEPLOY_EDITABLE = path.join(DEPLOY_DIR, "editableazuredeploy.json");
+const gitTag = process.argv[2];
+
+function setPackageUrl(armTemplate) {
+  const updatedPackageUrl = `https://github.com/Azure-Samples/communication-services-virtual-visits-js/releases/download/${gitTag}/sample.zip`;
+  const parsed = JSON.parse(fs.readFileSync(armTemplate));
+  parsed.variables.packageUrl = updatedPackageUrl;
+
+  const newPackageJSON = JSON.stringify(parsed, null, 2);
+  fs.writeFileSync(armTemplate, newPackageJSON);
+}
+
+function main() {
+  setPackageUrl(AZURE_DEPLOY);
+  setPackageUrl(AZURE_DEPLOY_EXISTING);
+  setPackageUrl(AZURE_DEPLOY_EDITABLE);
+}
+
+main();

--- a/scripts/set-arm-package-url.js
+++ b/scripts/set-arm-package-url.js
@@ -17,7 +17,9 @@ const AZURE_DEPLOY_EDITABLE = path.join(DEPLOY_DIR, "editableazuredeploy.json");
 const gitTag = process.argv[2];
 
 function setPackageUrl(armTemplate) {
-  const updatedPackageUrl = `https://github.com/Azure-Samples/communication-services-virtual-visits-js/releases/download/${gitTag}/sample.zip`;
+  const updatedPackageUrl = encodeURIComponent(
+    `https://github.com/Azure-Samples/communication-services-virtual-visits-js/releases/download/${gitTag}/sample.zip`
+  );
   const parsed = JSON.parse(fs.readFileSync(armTemplate));
   parsed.variables.packageUrl = updatedPackageUrl;
 

--- a/scripts/set-arm-package-url.js
+++ b/scripts/set-arm-package-url.js
@@ -17,9 +17,8 @@ const AZURE_DEPLOY_EDITABLE = path.join(DEPLOY_DIR, "editableazuredeploy.json");
 const gitTag = process.argv[2];
 
 function setPackageUrl(armTemplate) {
-  const updatedPackageUrl = encodeURIComponent(
-    `https://github.com/Azure-Samples/communication-services-virtual-visits-js/releases/download/${gitTag}/sample.zip`
-  );
+  const encodedGitTag = encodeURIComponent(gitTag);
+  const updatedPackageUrl = `https://github.com/Azure-Samples/communication-services-virtual-visits-js/releases/download/${encodedGitTag}/sample.zip`;
   const parsed = JSON.parse(fs.readFileSync(armTemplate));
   parsed.variables.packageUrl = updatedPackageUrl;
 


### PR DESCRIPTION
# What
Setting ARM templates package URL to the release tag version.

# Why
The ARM templates packageUrl is currently pointing to the latest version of Sample

# How Tested
Forked and ran the workflow 
Checked that the packageURL is being updated
https://github.com/tejaswip-msft/communication-services-virtual-visits-js/releases/tag/Release/1.0.4-test
   
 "packageUrl": "https://github.com/Azure-Samples/communication-services-virtual-visits-js/releases/download/Release/1.0.4-test/sample.zip",

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->