### PR TITLE
Increased the delay time to 5000 ms.

### DIFF
--- a/e2e-tests/tests/common/utils.ts
+++ b/e2e-tests/tests/common/utils.ts
@@ -15,7 +15,7 @@ export const buildUrl = (
   }
 };
 
-export const DELAY_MS = 1200;
+export const DELAY_MS = 5000;
 
 const getGUID = () => {
   return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
- Increased delay time on e2e test to 5000 ms because e2e test failed most of time because the application does not render on time (1200 ms currently).
- For instance, on [E2E tests for Sample workflows](https://github.com/Azure-Samples/communication-services-virtual-visits-js/actions/workflows/e2e-tests.yml) shows multiple failure because the application didn't render on time.
  ![image](https://user-images.githubusercontent.com/94404633/177228253-00c5a26f-3b2d-44b6-ac58-12c95e1537c8.png)


# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
- Hope this significant delay time crease stable the e2e test pipeline.

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->