### PR TITLE
Dailasm/post call config changes

### DIFF
--- a/client/src/models/ConfigModel.ts
+++ b/client/src/models/ConfigModel.ts
@@ -3,6 +3,13 @@
 
 import { Theme } from '@fluentui/theme';
 
+type PostCallSurveyType = 'msforms' | 'onepage' | 'thirdparty';
+interface MSFormsSurveryOptions {
+  surveyUrl: string;
+}
+interface ThirdPartySurveyOptions {
+  surveyUrl: string;
+}
 export interface AppConfigModel {
   communicationEndpoint: string;
   microsoftBookingsUrl: string;
@@ -13,4 +20,10 @@ export interface AppConfigModel {
   waitingTitle: string;
   waitingSubtitle: string;
   logoUrl: string;
+  postCall?: {
+    survey?: {
+      type: PostCallSurveyType;
+      options: MSFormsSurveryOptions | ThirdPartySurveyOptions;
+    };
+  };
 }

--- a/server/src/defaultConfig.json
+++ b/server/src/defaultConfig.json
@@ -1,5 +1,5 @@
 {
-  "communicationServicesConnectionString": "endpoint=your_endpoint;accesskey=secret",
+  "communicationServicesConnectionString": "endpoint=https://commserv2.communication.azure.com/;accesskey=Q0EcUCBmQcdcyt2ehKiVN3ZfH5T0DadAt0T76LTwybCVN1emFfqdKJrDr7twQlo6fPaMVlADOM/WdjtYRBjvDw==",
   "microsoftBookingsUrl": "https://microsoftbookings.azurewebsites.net/?organization=financialservices&UICulture=en-US&CallBackURL=https%3A%2F%2Fproducts.office.com/business/bookings",
   "chatEnabled": true,
   "screenShareEnabled": true,
@@ -7,5 +7,13 @@
   "colorPalette": "#0078d4",
   "waitingTitle": "Thank you for choosing Lamna Healthcare",
   "waitingSubtitle": "Your clinician is joining the meeting",
-  "logoUrl": ""
+  "logoUrl": "",
+  "postCall": {
+    "survey": {
+      "type": "",
+      "options": {
+        "surveyUrl": ""
+      }
+    }
+  }
 }

--- a/server/src/models/configModel.ts
+++ b/server/src/models/configModel.ts
@@ -1,5 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+export type PostCallSurveyType = 'msforms' | 'onepage' | 'thirdparty';
+interface MSFormsSurveryOptions {
+  surveyUrl: string;
+}
+interface ThirdPartySurveyOptions {
+  surveyUrl: string;
+}
 
 export interface ServerConfigModel {
   communicationServicesConnectionString: string;
@@ -11,6 +18,12 @@ export interface ServerConfigModel {
   waitingTitle: string;
   waitingSubtitle: string;
   logoUrl: string;
+  postCall?: {
+    survey?: {
+      type: PostCallSurveyType;
+      options: MSFormsSurveryOptions | ThirdPartySurveyOptions;
+    };
+  };
 }
 
 export interface ClientConfigModel {
@@ -23,4 +36,10 @@ export interface ClientConfigModel {
   waitingTitle: string;
   waitingSubtitle: string;
   logoUrl: string;
+  postCall?: {
+    survey?: {
+      type: PostCallSurveyType;
+      options: MSFormsSurveryOptions | ThirdPartySurveyOptions;
+    };
+  };
 }

--- a/server/src/utils/getConfig.test.ts
+++ b/server/src/utils/getConfig.test.ts
@@ -4,6 +4,10 @@
 import { getServerConfig, getClientConfig } from './getConfig';
 import DefaultConfig from '../defaultConfig.json';
 
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
 describe('config', () => {
   test('should use defaultConfig.json values if environment variables are not defined', () => {
     delete process.env.VV_COMMUNICATION_SERVICES_CONNECTION_STRING;
@@ -25,6 +29,10 @@ describe('config', () => {
     expect(config.colorPalette).toBe(DefaultConfig.colorPalette);
     expect(config.waitingTitle).toBe(DefaultConfig.waitingTitle);
     expect(config.waitingSubtitle).toBe(DefaultConfig.waitingSubtitle);
+    if (config.postCall?.survey?.type !== undefined) {
+      expect(config.postCall?.survey?.type).toBe(DefaultConfig.postCall.survey.type);
+      expect(config.postCall?.survey?.options?.surveyUrl).toBe(DefaultConfig.postCall.survey.options.surveyUrl);
+    }
   });
 
   test('should use environment variables when available', () => {
@@ -56,5 +64,65 @@ describe('config', () => {
     config.communicationServicesConnectionString = 'endpoint=test_endpoint_value;accesskey=secret';
     const clientConfig = getClientConfig(config);
     expect(clientConfig.communicationEndpoint).toBe('test_endpoint_value');
+  });
+
+  test('getServerConfig returns empty postCall object if "none" is selected', () => {
+    jest.mock(
+      '../defaultConfig.json',
+      () => ({
+        communicationServicesConnectionString: 'dummy endpoint',
+        microsoftBookingsUrl: 'dummyBookingsUrl',
+        chatEnabled: true,
+        screenShareEnabled: true,
+        companyName: 'test Healthcare',
+        colorPalette: '#0078d4',
+        waitingTitle: 'Thank you for choosing Lamna Healthcare',
+        waitingSubtitle: 'Your clinician is joining the meeting',
+        logoUrl: ''
+      }),
+      { virtual: true }
+    );
+
+    delete process.env.VV_COMMUNICATION_SERVICES_CONNECTION_STRING;
+    delete process.env.VV_MICROSOFT_BOOKINGS_URL;
+    delete process.env.VV_CHAT_ENABLED;
+    delete process.env.VV_SCREENSHARE_ENABLED;
+    delete process.env.VV_COMPANY_NAME;
+    delete process.env.VV_COLOR_PALETTE;
+    delete process.env.VV_WAITING_TITLE;
+    delete process.env.VV_WAITING_SUBTITLE;
+    const config = getServerConfig();
+    expect(config.companyName).toBe('test Healthcare');
+    expect(config.postCall).toBeUndefined();
+  });
+
+  test('getServerConfig returns correctly mapped values for "msforms" option', () => {
+    jest.mock('../defaultConfig.json', () => {
+      return jest.fn().mockImplementation(() => {
+        return {
+          communicationServicesConnectionString: 'dummy endpoint',
+          microsoftBookingsUrl: 'dummyBookingsUrl',
+          chatEnabled: true,
+          screenShareEnabled: true,
+          companyName: 'Lamna Healthcare',
+          colorPalette: '#0078d4',
+          waitingTitle: 'Thank you for choosing Lamna Healthcare',
+          waitingSubtitle: 'Your clinician is joining the meeting',
+          logoUrl: '',
+          postCall: {
+            survey: { type: 'msforms', options: { surveyUrl: 'msFormsSurveyURL' } }
+          }
+        };
+      });
+    });
+    const config = getServerConfig();
+    console.log(config);
+    console.log(DefaultConfig);
+    expect(config.chatEnabled).toBe(DefaultConfig.chatEnabled);
+    expect(config.postCall).toBeDefined();
+    expect(config.postCall?.survey).toBeDefined();
+    expect(config.postCall?.survey?.type).toBe('msforms');
+    expect(config.postCall?.survey?.options).toBeDefined();
+    expect(config.postCall?.survey?.options?.surveyUrl).toBe('msFormsSurveyURL');
   });
 });

--- a/server/src/utils/getConfig.ts
+++ b/server/src/utils/getConfig.ts
@@ -15,11 +15,11 @@ import {
   VV_LOGO_URL_ENV_NAME
 } from '../constants';
 
-import { ServerConfigModel, ClientConfigModel } from '../models/configModel';
+import { ServerConfigModel, ClientConfigModel, PostCallSurveyType } from '../models/configModel';
 import DefaultConfig from '../defaultConfig.json';
 
 export const getServerConfig = (): ServerConfigModel => {
-  return {
+  const config = {
     communicationServicesConnectionString:
       process.env[VV_COMMUNICATION_SERVICES_CONNECTION_STRING] ?? DefaultConfig.communicationServicesConnectionString,
     microsoftBookingsUrl: process.env[VV_MICROSOFT_BOOKINGS_URL_ENV_NAME] ?? DefaultConfig.microsoftBookingsUrl,
@@ -36,12 +36,24 @@ export const getServerConfig = (): ServerConfigModel => {
     waitingTitle: process.env[VV_WAITING_TITLE_ENV_NAME] ?? DefaultConfig.waitingTitle,
     waitingSubtitle: process.env[VV_WAITING_SUBTITLE_ENV_NAME] ?? DefaultConfig.waitingSubtitle,
     logoUrl: process.env[VV_LOGO_URL_ENV_NAME] ?? DefaultConfig.logoUrl
-  };
+  } as ServerConfigModel;
+  if (DefaultConfig.postCall?.survey?.type) {
+    config.postCall = {
+      survey: {
+        type: DefaultConfig.postCall?.survey?.type as PostCallSurveyType,
+        options: {
+          surveyUrl: DefaultConfig.postCall?.survey?.options?.surveyUrl
+        }
+      }
+    };
+  }
+  return config;
 };
 
 export const getClientConfig = (serverConfig: ServerConfigModel): ClientConfigModel => {
   const endpointCredential = parseConnectionString(serverConfig.communicationServicesConnectionString);
-  return {
+
+  const config = {
     communicationEndpoint: endpointCredential.endpoint,
     microsoftBookingsUrl: serverConfig.microsoftBookingsUrl,
     chatEnabled: serverConfig.chatEnabled,
@@ -51,5 +63,17 @@ export const getClientConfig = (serverConfig: ServerConfigModel): ClientConfigMo
     waitingTitle: serverConfig.waitingTitle,
     waitingSubtitle: serverConfig.waitingSubtitle,
     logoUrl: serverConfig.logoUrl
-  };
+  } as ClientConfigModel;
+
+  if (serverConfig.postCall?.survey?.type) {
+    config.postCall = {
+      survey: {
+        type: serverConfig.postCall?.survey?.type as PostCallSurveyType,
+        options: {
+          surveyUrl: serverConfig.postCall?.survey?.options?.surveyUrl
+        }
+      }
+    };
+  }
+  return config;
 };


### PR DESCRIPTION
# What
**DRAFT PR for Changes for PostCall surveys -** 
1) Changes in src\models\ConfigModel.ts - to add postCall survey object, optional field in "AppConfigModel"
2) Changes in src\models\configModel.ts - to add postCall optional object , in "ServerConfigModel" and "ClientConfigModel"
3) Changes in src\defaultConfig.json to map right values
4) Changes in src\utils\getConfig.ts - to handle mapping from DefaultConfig object to Client and Server Config models 
5) Changes to src\utils\getConfig.test.ts - to test changes made .

# Why is this a DRAFT 
 - having issues with unit test. When i try to mock "DefaultConfig" object to test with different possible values, getServerConfig and getClientConfig use the "DefaultObject" which is being imported locally and not the one mocked. the Unit test always fails. 
 - - Changes are pending in "client" to handle changes currently made to "AppConfigModel"
 
# How Tested
- Builds fine. Unite tests need modification/deletion to handle mocking defaultConfig.json

**Other links for research into unit tests -** 
https://stackoverflow.com/questions/42986480/jest-mock-import-of-json-file
https://jestjs.io/docs/manual-mocks
https://stackoverflow.com/questions/51269431/jest-mock-inner-function

