### PR TITLE
survey fhl integation into current sample

### DIFF
--- a/client/src/Visit.tsx
+++ b/client/src/Visit.tsx
@@ -116,6 +116,7 @@ export const Visit = (): JSX.Element => {
             waitingTitle={config.waitingTitle}
             waitingSubtitle={config.waitingSubtitle}
             chatEnabled={config.chatEnabled}
+            postCall={config.postCall}
             onDisplayError={(error) => setError(error)}
           />
         </LayerHost>

--- a/client/src/components/MeetingExperience.test.tsx
+++ b/client/src/components/MeetingExperience.test.tsx
@@ -14,6 +14,8 @@ import {
   createMockStatefulChatClient,
   runFakeTimers
 } from '../utils/TestUtils';
+import { PostCallConfig } from '../models/ConfigModel';
+import { Survey } from '../components/Survey';
 
 configure({ adapter: new Adapter() });
 
@@ -41,6 +43,15 @@ jest.mock('@azure/communication-common', () => {
   };
 });
 
+const mockPostCall: PostCallConfig = {
+  survey: {
+    type: 'msforms',
+    options: {
+      surveyUrl: 'dummySurveyUrl'
+    }
+  }
+};
+
 describe('MeetingExperience', () => {
   const waitingTitle = 'waiting title';
   const waitingSubtitle = 'waiting subtitle';
@@ -67,6 +78,7 @@ describe('MeetingExperience', () => {
         waitingSubtitle={waitingSubtitle}
         logoUrl={logoUrl}
         chatEnabled={true}
+        postCall={mockPostCall}
         onDisplayError={jest.fn()}
       />
     );
@@ -104,6 +116,7 @@ describe('MeetingExperience', () => {
         waitingSubtitle={waitingSubtitle}
         logoUrl={logoUrl}
         chatEnabled={true}
+        postCall={mockPostCall}
         onDisplayError={jest.fn()}
       />
     );
@@ -115,5 +128,31 @@ describe('MeetingExperience', () => {
 
     expect(callWithChatComposites.length).toBe(1);
     expect(callWithChatComposites.first().props().formFactor).toEqual('mobile');
+  });
+
+  it('should render Survey component', async () => {
+    const meetingExperience = await mount(
+      <MeetingExperience
+        userId={{ communicationUserId: 'test' }}
+        token={'token'}
+        displayName={'name'}
+        endpointUrl={'endpoint'}
+        locator={{ meetingLink: 'meeting link' }}
+        fluentTheme={undefined}
+        waitingTitle={waitingTitle}
+        waitingSubtitle={waitingSubtitle}
+        logoUrl={logoUrl}
+        chatEnabled={true}
+        postCall={mockPostCall}
+        onDisplayError={jest.fn()}
+      />
+    );
+
+    await runFakeTimers();
+    meetingExperience.update();
+    meetingExperience.instance().setState({ renderPostCall: true });
+    const survey = meetingExperience.find(Survey);
+
+    expect(survey.length).toBe(1);
   });
 });

--- a/client/src/components/MeetingExperience.test.tsx
+++ b/client/src/components/MeetingExperience.test.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import React from 'react';
 import { CallWithChatComposite } from '@azure/communication-react';
 import { setIconOptions } from '@fluentui/react';
 import { configure, mount } from 'enzyme';
@@ -86,7 +87,7 @@ describe('MeetingExperience', () => {
     await runFakeTimers();
     meetingExperience.update();
     const callWithChatComposites = meetingExperience.find(CallWithChatComposite);
-
+    console.log(callWithChatComposites);
     expect(callWithChatComposites.length).toBe(1);
     expect(callWithChatComposites.first().props().locale?.strings.call.lobbyScreenWaitingToBeAdmittedTitle).toBe(
       waitingTitle
@@ -131,6 +132,10 @@ describe('MeetingExperience', () => {
   });
 
   it('should render Survey component', async () => {
+    const setRenderPostCallMock = jest.fn();
+    const useStateMock: any = (_: any) => [true, setRenderPostCallMock];
+    jest.spyOn(React, 'useState').mockImplementation(useStateMock);
+
     const meetingExperience = await mount(
       <MeetingExperience
         userId={{ communicationUserId: 'test' }}
@@ -149,10 +154,12 @@ describe('MeetingExperience', () => {
     );
 
     await runFakeTimers();
+
     meetingExperience.update();
-    meetingExperience.instance().setState({ renderPostCall: true });
     const survey = meetingExperience.find(Survey);
+    const callWithChatComposites = meetingExperience.find(CallWithChatComposite);
 
     expect(survey.length).toBe(1);
+    expect(callWithChatComposites.length).toBe(0);
   });
 });

--- a/client/src/components/MeetingExperience.tsx
+++ b/client/src/components/MeetingExperience.tsx
@@ -21,6 +21,7 @@ import { meetingExperienceLogoStyles } from '../styles/MeetingExperience.styles'
 import { createStubChatClient } from '../utils/stubs/chat';
 import { Survey } from '../components/Survey';
 import ReactDOM from 'react-dom';
+import { PostCallConfig } from '../models/ConfigModel';
 
 export interface MeetingExperienceProps {
   userId: CommunicationUserIdentifier;
@@ -33,6 +34,7 @@ export interface MeetingExperienceProps {
   waitingSubtitle: string;
   logoUrl: string;
   chatEnabled: boolean;
+  postCall: PostCallConfig | undefined;
   onDisplayError(error: any): void;
 }
 
@@ -48,10 +50,12 @@ export const MeetingExperience = (props: MeetingExperienceProps): JSX.Element =>
     userId,
     waitingSubtitle,
     waitingTitle,
+    postCall,
     onDisplayError
   } = props;
 
   const [callWithChatAdapter, setCallWithChatAdapter] = useState<CallWithChatAdapter | undefined>(undefined);
+  const [renderPostCall, setRenderPostCall] = useState(false);
 
   const credential = useMemo(() => new AzureCommunicationTokenCredential(token), [token]);
 
@@ -67,13 +71,9 @@ export const MeetingExperience = (props: MeetingExperienceProps): JSX.Element =>
           chatEnabled
         );
         adapter.on('callEnded', async () => {
-          ReactDOM.render(
-            <React.StrictMode>
-              <Survey />
-              <Link onClick={() => adapter.joinCall()}>{'or re-join the call'}</Link>
-            </React.StrictMode>,
-            document.getElementById('root')
-          );
+          if (postCall?.survey?.type && postCall?.survey?.type === 'msforms') {
+            setRenderPostCall(true);
+          }
         });
         setCallWithChatAdapter(adapter);
       } catch (err) {
@@ -120,7 +120,6 @@ export const MeetingExperience = (props: MeetingExperienceProps): JSX.Element =>
       />
     );
   }
-
   if (credential === undefined) {
     return <>Failed to construct credential. Provided token is malformed.</>;
   }

--- a/client/src/components/MeetingExperience.tsx
+++ b/client/src/components/MeetingExperience.tsx
@@ -11,14 +11,16 @@ import {
   createAzureCommunicationCallWithChatAdapterFromClients,
   createStatefulChatClient
 } from '@azure/communication-react';
-import { Theme, PartialTheme, Spinner } from '@fluentui/react';
+import { Theme, PartialTheme, Spinner, Link } from '@fluentui/react';
 import MobileDetect from 'mobile-detect';
-import { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { getApplicationName, getApplicationVersion } from '../utils/GetAppInfo';
 import { getChatThreadIdFromTeamsLink } from '../utils/GetTeamsMeetingLink';
 import { fullSizeStyles } from '../styles/Common.styles';
 import { meetingExperienceLogoStyles } from '../styles/MeetingExperience.styles';
 import { createStubChatClient } from '../utils/stubs/chat';
+import { Survey } from '../components/Survey';
+import ReactDOM from 'react-dom';
 
 export interface MeetingExperienceProps {
   userId: CommunicationUserIdentifier;
@@ -64,7 +66,15 @@ export const MeetingExperience = (props: MeetingExperienceProps): JSX.Element =>
           endpointUrl,
           chatEnabled
         );
-
+        adapter.on('callEnded', async () => {
+          ReactDOM.render(
+            <React.StrictMode>
+              <Survey />
+              <Link onClick={() => adapter.joinCall()}>{'or re-join the call'}</Link>
+            </React.StrictMode>,
+            document.getElementById('root')
+          );
+        });
         setCallWithChatAdapter(adapter);
       } catch (err) {
         // todo: error logging

--- a/client/src/components/Survey.test.tsx
+++ b/client/src/components/Survey.test.tsx
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { Survey, SurveyProps } from './Survey';
+import { PostCallConfig } from '../models/ConfigModel';
+import { configure, mount } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+configure({ adapter: new Adapter() });
+
+const mockPostCall: PostCallConfig = {
+  survey: {
+    type: 'msforms',
+    options: {
+      surveyUrl: 'dummySurveyUrl'
+    }
+  }
+};
+
+describe('Survey', () => {
+  it('should render', async () => {
+    const survey = await mount<SurveyProps>(<Survey postCall={mockPostCall} onRejoinCall={jest.fn()} />);
+    expect(survey.find('iframe').length).toBe(1);
+    expect(survey.props().postCall?.survey?.type).toBe(mockPostCall.survey?.type);
+    expect(survey.props().postCall?.survey?.options.surveyUrl).toBe(mockPostCall.survey?.options.surveyUrl);
+  });
+});

--- a/client/src/components/Survey.tsx
+++ b/client/src/components/Survey.tsx
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import React from 'react';
+import { LayerHost, Spinner, Stack, ThemeProvider } from '@fluentui/react';
+import { backgroundStyles, fullSizeStyles } from '../styles/Common.styles';
+import { embededIframeStyles } from '../styles/Book.styles';
+import { Header } from '../Header';
+import { fetchConfig } from '../utils/FetchConfig';
+import { AppConfigModel } from '../models/ConfigModel';
+import { GenericError } from '../components/GenericError';
+
+interface SurveyState {
+  config: AppConfigModel | undefined;
+  error: any | undefined;
+}
+
+interface SurveyProps {
+  children?: React.ReactNode;
+}
+
+export class Survey extends React.Component<SurveyProps, SurveyState> {
+  public constructor(props: SurveyProps) {
+    super(props);
+
+    this.state = {
+      config: undefined,
+      error: undefined
+    };
+  }
+
+  async componentDidMount(): Promise<void> {
+    try {
+      const config = await fetchConfig();
+      this.setState({ config });
+    } catch (error) {
+      console.error(error);
+      this.setState({ error });
+    }
+  }
+
+  render(): JSX.Element {
+    const parentID = 'SurveySection';
+    if (this.state.config) {
+      return (
+        <ThemeProvider theme={this.state.config.theme} style={{ height: '100%' }}>
+          <Stack styles={backgroundStyles(this.state.config.theme)}>
+            <Header companyName={this.state.config.companyName} parentid={parentID} />
+            <LayerHost
+              id={parentID}
+              style={{
+                position: 'relative',
+                height: '100%'
+              }}
+            >
+              <iframe
+                src={this.state.config.postCall?.survey?.options.surveyUrl}
+                scrolling="yes"
+                style={embededIframeStyles}
+              ></iframe>
+            </LayerHost>
+          </Stack>
+        </ThemeProvider>
+      );
+    } else if (this.state.error) {
+      return <GenericError statusCode={this.state.error.statusCode} />;
+    } else {
+      return <Spinner styles={fullSizeStyles} />;
+    }
+  }
+}

--- a/client/src/components/Survey.tsx
+++ b/client/src/components/Survey.tsx
@@ -2,70 +2,34 @@
 // Licensed under the MIT license.
 
 import React from 'react';
-import { LayerHost, Spinner, Stack, ThemeProvider } from '@fluentui/react';
-import { backgroundStyles, fullSizeStyles } from '../styles/Common.styles';
-import { embededIframeStyles } from '../styles/Book.styles';
-import { Header } from '../Header';
-import { fetchConfig } from '../utils/FetchConfig';
-import { AppConfigModel } from '../models/ConfigModel';
-import { GenericError } from '../components/GenericError';
+import { Link, Stack } from '@fluentui/react';
+import { PostCallConfig } from '../models/ConfigModel';
+import { rejoinLinkStyle, surveyStyle } from '../styles/Survey.styles';
 
-interface SurveyState {
-  config: AppConfigModel | undefined;
-  error: any | undefined;
+export interface SurveyProps {
+  onRejoinCall: () => void;
+  postCall?: PostCallConfig;
 }
+const SURVEY = 'SurveyComponent';
 
-interface SurveyProps {
-  children?: React.ReactNode;
-}
-
-export class Survey extends React.Component<SurveyProps, SurveyState> {
-  public constructor(props: SurveyProps) {
-    super(props);
-
-    this.state = {
-      config: undefined,
-      error: undefined
-    };
-  }
-
-  async componentDidMount(): Promise<void> {
-    try {
-      const config = await fetchConfig();
-      this.setState({ config });
-    } catch (error) {
-      console.error(error);
-      this.setState({ error });
-    }
-  }
-
-  render(): JSX.Element {
-    const parentID = 'SurveySection';
-    if (this.state.config) {
-      return (
-        <ThemeProvider theme={this.state.config.theme} style={{ height: '100%' }}>
-          <Stack styles={backgroundStyles(this.state.config.theme)}>
-            <Header companyName={this.state.config.companyName} parentid={parentID} />
-            <LayerHost
-              id={parentID}
-              style={{
-                position: 'relative',
-                height: '100%'
-              }}
-            >
-              <iframe
-                src={this.state.config.postCall?.survey?.options.surveyUrl}
-                scrolling="yes"
-                style={embededIframeStyles}
-              ></iframe>
-            </LayerHost>
-          </Stack>
-        </ThemeProvider>
-      );
-    } else if (this.state.error) {
-      return <GenericError statusCode={this.state.error.statusCode} />;
-    } else {
-      return <Spinner styles={fullSizeStyles} />;
-    }
-  }
-}
+export const Survey: React.FunctionComponent<SurveyProps> = (props: SurveyProps) => {
+  return (
+    <Stack styles={surveyStyle}>
+      <iframe
+        title={SURVEY}
+        style={{ height: '100%', width: '100%', border: 0 }}
+        src={props.postCall?.survey?.options.surveyUrl}
+        scrolling="yes"
+      ></iframe>
+      <Stack horizontalAlign="center" verticalAlign="center" styles={rejoinLinkStyle}>
+        <Link
+          onClick={() => {
+            void props.onRejoinCall();
+          }}
+        >
+          {'or re-join the call'}
+        </Link>
+      </Stack>
+    </Stack>
+  );
+};

--- a/client/src/models/ConfigModel.ts
+++ b/client/src/models/ConfigModel.ts
@@ -3,7 +3,7 @@
 
 import { Theme } from '@fluentui/theme';
 
-type PostCallSurveyType = 'msforms' | 'thirdparty';
+export type PostCallSurveyType = 'msforms' | 'thirdparty';
 interface MSFormsSurveryOptions {
   surveyUrl: string;
 }

--- a/client/src/models/ConfigModel.ts
+++ b/client/src/models/ConfigModel.ts
@@ -10,6 +10,13 @@ interface MSFormsSurveryOptions {
 interface ThirdPartySurveyOptions {
   surveyUrl: string;
 }
+
+export interface PostCallConfig {
+  survey?: {
+    type: PostCallSurveyType;
+    options: MSFormsSurveryOptions | ThirdPartySurveyOptions;
+  };
+}
 export interface AppConfigModel {
   communicationEndpoint: string;
   microsoftBookingsUrl: string;
@@ -20,10 +27,5 @@ export interface AppConfigModel {
   waitingTitle: string;
   waitingSubtitle: string;
   logoUrl: string;
-  postCall?: {
-    survey?: {
-      type: PostCallSurveyType;
-      options: MSFormsSurveryOptions | ThirdPartySurveyOptions;
-    };
-  };
+  postCall?: PostCallConfig;
 }

--- a/client/src/styles/Survey.styles.ts
+++ b/client/src/styles/Survey.styles.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+export const surveyStyle = {
+  root: { paddingTop: '2.25rem', paddingLeft: '3.75rem', paddingRight: '3.75rem', height: '100%' }
+};
+
+export const rejoinLinkStyle = { root: { height: '5rem' } };

--- a/server/src/defaultConfig.json
+++ b/server/src/defaultConfig.json
@@ -7,5 +7,13 @@
   "colorPalette": "#0078d4",
   "waitingTitle": "Thank you for choosing Lamna Healthcare",
   "waitingSubtitle": "Your clinician is joining the meeting",
-  "logoUrl": ""
+  "logoUrl": "",
+  "postCall": {
+    "survey": {
+      "type": "msforms",
+      "options": {
+        "surveyUrl": "https://forms.microsoft.com/Pages/ResponsePage.aspx?id=v4j5cvGGr0GRqy180BHbR0bub2Uua3hJoCvbHUQHrfJUOUJSRjhKWEFUVlFDVFZZMUcyVUFEMklGVy4u"
+      }
+    }
+  }
 }


### PR DESCRIPTION
# What
First integration of FHL postcall into sample code. 
The following is being worked upon - 
 - Pass in config (remove separate fetchConfig api call within survey component) and bring in checks wether SurveyForm or Noticepage is to be shown

# Why
Brainstorming on ways to implement "re-join call"
