### PR TITLE
Removed padding,avoids new tab on small screens

### DIFF
--- a/client/src/styles/Survey.styles.ts
+++ b/client/src/styles/Survey.styles.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 export const surveyStyle = {
-  root: { paddingTop: '2.25rem', paddingLeft: '3.75rem', paddingRight: '3.75rem', height: '100%' }
+  root: { height: '100%' }
 };
 
 export const rejoinLinkStyle = { root: { height: '5rem', textDecoration: 'underline' } };


### PR DESCRIPTION
# What
Removed padding to avoid opening a new tab when postcall survey is loaded on smaller screens

# Why
Comments from UX review

# How Tested
Mobile and Dektop - 
![image](https://user-images.githubusercontent.com/100614160/193901440-8e73b623-92b1-4337-b248-263693335eaa.png)

![image](https://user-images.githubusercontent.com/100614160/193901497-09d928bd-3aab-476a-be92-5336f28820a1.png)

