### PR TITLE
Set CosmosDB endpoint as higher precedence than connection string

### DIFF
--- a/server/src/databaseHandlers/surveyDBHandler.test.ts
+++ b/server/src/databaseHandlers/surveyDBHandler.test.ts
@@ -109,7 +109,7 @@ describe('Test createSurveyDBHandler', () => {
 
     const surveyDBHandler = createSurveyDBHandler(config as ServerConfigModel);
 
-    expect(surveyDBHandler).not.toBeUndefined();
+    expect(surveyDBHandler).toBeDefined();
   });
 
   test('Test createSurveyDBHandler with only postCall exists', () => {
@@ -169,7 +169,7 @@ describe('Test createSurveyDBHandler', () => {
 
     const surveyDBHandler = createSurveyDBHandler(config as ServerConfigModel);
 
-    expect(surveyDBHandler).not.toBeUndefined();
+    expect(surveyDBHandler).toBeDefined();
   });
 
   test('Test createSurveyDBHandler with cosmosDb connectionString with empty', () => {

--- a/server/src/databaseHandlers/surveyDBHandler.ts
+++ b/server/src/databaseHandlers/surveyDBHandler.ts
@@ -10,9 +10,7 @@ import { ServerConfigModel } from '../models/configModel';
 const surveyContainerName = 'Surveys';
 
 const createCosmosClient = (config): CosmosClient => {
-  if (config.cosmosDb.connectionString && config.cosmosDb.connectionString.length > 0) {
-    return new CosmosClient(config.cosmosDb.connectionString);
-  } else {
+  if (config.cosmosDb.endpoint && config.cosmosDb.endpoint.length > 0) {
     const cosmosClientOptions: CosmosClientOptions = {
       endpoint: config.cosmosDb.endpoint as string,
       aadCredentials: new DefaultAzureCredential()
@@ -20,6 +18,8 @@ const createCosmosClient = (config): CosmosClient => {
 
     return new CosmosClient(cosmosClientOptions);
   }
+
+  return new CosmosClient(config.cosmosDb.connectionString);
 };
 
 export const createSurveyDBHandler = (config: ServerConfigModel): SurveyDBHandler | undefined => {
@@ -35,7 +35,6 @@ export const createSurveyDBHandler = (config: ServerConfigModel): SurveyDBHandle
 };
 
 export default class SurveyDBHandler {
-  public connection;
   private cosmosClient: CosmosClient;
   private cosmosDBConfig: CosmosDBConfig;
 


### PR DESCRIPTION
# What
If both endpoint and connection string are defined, use the endpoint.

# Why
In case the endpoint environment variable is defined while the connection string environment variable is not, and if the connection string is defined in the default Config, the connection string will be used even if it is empty or a dummy string. The expectation is that the endpoint should be used.

When Contoso deploys via ARM template, the ARM templates set the VV_COSMOSDB_ENDPOINT environment variable which should tell the app to use the endpoint.

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->