### PR TITLE
Change default cosmosDbName in ARM templates to be simpler

### DIFF
--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -63,8 +63,8 @@
     "postCallSurveyOneQuestionPollAnswerPlaceholder": "",
     "postCallSurveyOneQuestionPollSaveButtonText": "",
     "cosmosDbAccountName": "[concat('db-account-', parameters('appServiceName'))]",
+    "cosmosDbName": "myDatabase",
     "roleDefinitionName": "[concat('sql-role-definition-', parameters('appServiceName'))]",
-    "cosmosDbName": "[concat('cosmos-db-', parameters('appServiceName'))]",
     "roleDefinitionId": "[guid('sql-role-definition-', resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosDbAccountName')))]",
     "roleAssignmentId": "[guid(variables('roleDefinitionId'), resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosDbAccountName')))]"
   },

--- a/deploy/azuredeployexistingresource.json
+++ b/deploy/azuredeployexistingresource.json
@@ -36,8 +36,8 @@
     "postCallSurveyOneQuestionPollAnswerPlaceholder": "",
     "postCallSurveyOneQuestionPollSaveButtonText": "",
     "cosmosDbAccountName": "[concat('db-account-', parameters('appServiceName'))]",
+    "cosmosDbName": "myDatabase",
     "roleDefinitionName": "[concat('sql-role-definition-', parameters('appServiceName'))]",
-    "cosmosDbName": "[concat('cosmos-db-', parameters('appServiceName'))]",
     "roleDefinitionId": "[guid('sql-role-definition-', resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosDbAccountName')))]",
     "roleAssignmentId": "[guid(variables('roleDefinitionId'), resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosDbAccountName')))]"
   },


### PR DESCRIPTION
# What
Simplifying the default db name

![2022-10-11 15_27_02-rgabrinao-oct22-tapdemo-cosmos - Microsoft Azure — Mozilla Firefox](https://user-images.githubusercontent.com/43504546/195210293-5cf16e4c-09b1-4a1b-9dd1-8e10c9c92189.png)

# Why
The previous default name was derived from the app service name. To be consistent with the default db name in the defaultConfig.json and the Builder config, a simpler name is proposed here.

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->