### PR TITLE
Add dependsOn condition for AppService resource in ARM Templates

### DIFF
--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -104,7 +104,8 @@
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanPortalName'))]",
-        "[resourceId('Microsoft.Communication/communicationServices', parameters('communicationServiceName'))]"
+        "[resourceId('Microsoft.Communication/communicationServices', parameters('communicationServiceName'))]",
+        "[resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosDbAccountName'))]"
       ],
       "properties": {
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanPortalName'))]",

--- a/deploy/azuredeployexistingresource.json
+++ b/deploy/azuredeployexistingresource.json
@@ -66,7 +66,8 @@
       "name": "[parameters('appServiceName')]",
       "location": "[resourceGroup().location]",
       "dependsOn": [
-        "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanPortalName'))]"
+        "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanPortalName'))]",
+        "[resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosDbAccountName'))]"
       ],
       "properties": {
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanPortalName'))]",

--- a/deploy/editableazuredeploy.json
+++ b/deploy/editableazuredeploy.json
@@ -153,7 +153,8 @@
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanPortalName'))]",
-        "[resourceId('Microsoft.Communication/communicationServices', parameters('communicationServiceName'))]"
+        "[resourceId('Microsoft.Communication/communicationServices', parameters('communicationServiceName'))]",
+        "[resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosDbAccountName'))]"
       ],
       "properties": {
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanPortalName'))]",


### PR DESCRIPTION
# What
Currently, the App Service resource in ARM does not depend on the Cosmos DB resource, which means they are provisioned concurrently. This can cause an issue if the app starts before Cosmos DB finishes provisioning since the app won't be able to create the db and container. The fix is to make the AppService resource dependsOn the Cosmos DB resource.

ARM is smart enough to remove the dependency if the prerequisite resource is conditionally deployed: https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/resource-dependency#dependson

# Why
So that the app is able to create the db and container when it starts up

# How Tested
Deployed to Azure two apps - one with one question poll, one without. Confirmed that the resources are successfully deployed

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->