### PR TITLE
Add warning banner if using specimen Bookings page

### DIFF
--- a/client/jest.config.js
+++ b/client/jest.config.js
@@ -114,7 +114,7 @@ module.exports = {
   // runner: "jest-runner",
 
   // The paths to modules that run some code to configure or set up the testing environment before each test
-  // setupFiles: [],
+  setupFiles: ['./src/setupTests.js'],
 
   // A list of paths to modules that run some code to configure or set up the testing framework before each test
   // setupFilesAfterEnv: [],

--- a/client/src/Book.test.tsx
+++ b/client/src/Book.test.tsx
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { setIconOptions, Spinner } from '@fluentui/react';
-import { configure, mount } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import { Spinner } from '@fluentui/react';
+import { mount } from 'enzyme';
 import { Book } from './Book';
 import { Header } from './Header';
 import { GenericError } from './components/GenericError';
@@ -11,14 +10,8 @@ import { AppConfigModel } from './models/ConfigModel';
 import * as FetchConfig from './utils/FetchConfig';
 import { runFakeTimers } from './utils/TestUtils';
 import { generateTheme } from './utils/ThemeGenerator';
-
-configure({ adapter: new Adapter() });
-
-// Disable icon warnings for tests as we don't register the icons for unit tests which causes warnings.
-// See: https://github.com/microsoft/fluentui/wiki/Using-icons#test-scenarios
-setIconOptions({
-  disableWarnings: true
-});
+import { BOOKINGS_SPECIMEN_URL } from './utils/Constants';
+import WarningBanner from './components/Book/WarningBanner';
 
 describe('Book', () => {
   beforeEach(() => {
@@ -89,10 +82,46 @@ describe('Book', () => {
     const spinners = book.find(Spinner);
     const headers = book.find(Header);
     const iframes = book.find('iframe');
+    const warningBanner = book.find(WarningBanner);
 
     expect(spinners.length).toBe(0);
+    expect(warningBanner.length).toBe(0);
     expect(headers.length).toBe(1);
     expect(iframes.length).toBe(1);
     expect(iframes.first().props().src).toBe(mockBookingsUrl);
+  });
+
+  it('should render warning banner if using specimen Bookings page', async () => {
+    const fetchConfigSpy = jest.spyOn(FetchConfig, 'fetchConfig');
+    fetchConfigSpy.mockReturnValue(
+      Promise.resolve({
+        communicationEndpoint: 'endpoint=test_endpoint;',
+        microsoftBookingsUrl: BOOKINGS_SPECIMEN_URL,
+        chatEnabled: true,
+        screenShareEnabled: true,
+        companyName: '',
+        theme: generateTheme('#FFFFFF'),
+        waitingTitle: '',
+        waitingSubtitle: '',
+        logoUrl: ''
+      } as AppConfigModel)
+    );
+
+    const book = await mount(<Book />);
+
+    await runFakeTimers();
+
+    book.update();
+
+    const spinners = book.find(Spinner);
+    const headers = book.find(Header);
+    const iframes = book.find('iframe');
+    const warningBanner = book.find(WarningBanner);
+
+    expect(spinners.length).toBe(0);
+    expect(warningBanner.length).toBe(1);
+    expect(headers.length).toBe(1);
+    expect(iframes.length).toBe(1);
+    expect(iframes.first().props().src).toBe(BOOKINGS_SPECIMEN_URL);
   });
 });

--- a/client/src/Book.tsx
+++ b/client/src/Book.tsx
@@ -10,6 +10,8 @@ import { fetchConfig } from './utils/FetchConfig';
 import { AppConfigModel } from './models/ConfigModel';
 import { GenericError } from './components/GenericError';
 import { useEffect, useState } from 'react';
+import { BOOKINGS_SPECIMEN_URL } from './utils/Constants';
+import WarningBanner from './components/Book/WarningBanner';
 
 const PARENT_ID = 'BookMeetingSection';
 
@@ -43,6 +45,7 @@ export const Book = (): JSX.Element => {
               height: '100%'
             }}
           >
+            {config.microsoftBookingsUrl === BOOKINGS_SPECIMEN_URL ? <WarningBanner /> : <></>}
             <iframe src={config.microsoftBookingsUrl} scrolling="yes" style={embededIframeStyles}></iframe>
           </LayerHost>
         </Stack>

--- a/client/src/Header.test.tsx
+++ b/client/src/Header.test.tsx
@@ -1,19 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { IconButton, Text, setIconOptions, Panel } from '@fluentui/react';
-import { configure, mount } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import { IconButton, Text, Panel } from '@fluentui/react';
+import { mount } from 'enzyme';
 import { Header } from './Header';
 import { WaffleMenu } from './WaffleMenu';
-
-configure({ adapter: new Adapter() });
-
-// Disable icon warnings for tests as we don't register the icons for unit tests which causes warnings.
-// See: https://github.com/microsoft/fluentui/wiki/Using-icons#test-scenarios
-setIconOptions({
-  disableWarnings: true
-});
 
 describe('Header', () => {
   it('should render icon, waffle menu with panel, and company name', () => {

--- a/client/src/Visit.test.tsx
+++ b/client/src/Visit.test.tsx
@@ -3,9 +3,8 @@
 
 import { CommunicationUserToken } from '@azure/communication-identity';
 import { TeamsMeetingLinkLocator } from '@azure/communication-calling';
-import { setIconOptions, Spinner } from '@fluentui/react';
-import { configure, mount } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import { Spinner } from '@fluentui/react';
+import { mount } from 'enzyme';
 import { Header } from './Header';
 import { Visit } from './Visit';
 import { GenericError } from './components/GenericError';
@@ -23,14 +22,6 @@ import {
   createMockStatefulChatClient,
   runFakeTimers
 } from './utils/TestUtils';
-
-configure({ adapter: new Adapter() });
-
-// Disable icon warnings for tests as we don't register the icons for unit tests which causes warnings.
-// See: https://github.com/microsoft/fluentui/wiki/Using-icons#test-scenarios
-setIconOptions({
-  disableWarnings: true
-});
 
 jest.mock('@azure/communication-react', () => {
   return {

--- a/client/src/WaffleMenu.test.tsx
+++ b/client/src/WaffleMenu.test.tsx
@@ -1,20 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { setIconOptions, Panel } from '@fluentui/react';
-import { configure, mount } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import { Panel } from '@fluentui/react';
+import { mount } from 'enzyme';
 import * as renderer from 'react-test-renderer';
 import { WaffleMenu, WaffleNavigation } from './WaffleMenu';
 import { runFakeTimers } from './utils/TestUtils';
-
-configure({ adapter: new Adapter() });
-
-// Disable icon warnings for tests as we don't register the icons for unit tests which causes warnings.
-// See: https://github.com/microsoft/fluentui/wiki/Using-icons#test-scenarios
-setIconOptions({
-  disableWarnings: true
-});
 
 describe('WaffleMenu', () => {
   it('should have a Waffle icon and a closed Panel', async () => {

--- a/client/src/components/Book/WarningBanner.test.tsx
+++ b/client/src/components/Book/WarningBanner.test.tsx
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as renderer from 'react-test-renderer';
+import WarningBanner, { WarningMessage } from './WarningBanner';
+
+describe('WarningBanner', () => {
+  it('matches snapshot', () => {
+    const component = renderer.create(<WarningBanner />).toJSON();
+    expect(component).toMatchSnapshot();
+  });
+});
+
+describe('WarningMessage', () => {
+  it('matches snapshot', () => {
+    const component = renderer.create(<WarningMessage />).toJSON();
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/client/src/components/Book/WarningBanner.tsx
+++ b/client/src/components/Book/WarningBanner.tsx
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { MessageBar, MessageBarType, Text, Link } from '@fluentui/react';
+import { BOOKINGS_README_URL } from '../../utils/Constants';
+
+const WarningBanner = (): JSX.Element => {
+  return (
+    <MessageBar messageBarType={MessageBarType.warning} isMultiline={false} dismissButtonAriaLabel="Close">
+      <WarningMessage />
+    </MessageBar>
+  );
+};
+
+// Extracting to a component since MessageBar is not rendering child components in tests
+export const WarningMessage = (): JSX.Element => {
+  return (
+    <>
+      <Text>This Booking page is a specimen and will not create appointments or send reminders.</Text>
+      <Link href={BOOKINGS_README_URL} target="_blank" underline>
+        <Text>Check out the sample readme.</Text>
+      </Link>
+    </>
+  );
+};
+
+export default WarningBanner;

--- a/client/src/components/Book/__snapshots__/WarningBanner.test.tsx.snap
+++ b/client/src/components/Book/__snapshots__/WarningBanner.test.tsx.snap
@@ -1,0 +1,54 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`WarningBanner matches snapshot 1`] = `
+<div
+  className="ms-MessageBar ms-MessageBar--warning ms-MessageBar-singleline root-109"
+>
+  <div
+    className="ms-MessageBar-content content-110"
+  >
+    <div
+      aria-hidden={true}
+      className="ms-MessageBar-icon iconContainer-111"
+    >
+      <i
+        aria-hidden={true}
+        className="icon-118"
+        data-icon-name="Info"
+      />
+    </div>
+    <div
+      aria-live="polite"
+      className="ms-MessageBar-text text-113"
+      id="MessageBar0"
+      role="status"
+    >
+      <span
+        className="ms-MessageBar-innerText innerText-114"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`WarningMessage matches snapshot 1`] = `
+Array [
+  <span
+    className="css-119"
+  >
+    This Booking page is a specimen and will not create appointments or send reminders.
+  </span>,
+  <a
+    className="ms-Link root-120"
+    href="https://aka.ms/virtual-appointments-sample-bookings"
+    onClick={[Function]}
+    target="_blank"
+  >
+    <span
+      className="css-119"
+    >
+      Check out the sample readme.
+    </span>
+  </a>,
+]
+`;

--- a/client/src/components/JoinTeamsMeeting.test.tsx
+++ b/client/src/components/JoinTeamsMeeting.test.tsx
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { LayerHost, PrimaryButton, setIconOptions, Stack, TextField } from '@fluentui/react';
+import { LayerHost, PrimaryButton, Stack, TextField } from '@fluentui/react';
 import { mount } from 'enzyme';
 import { generateTheme } from '../utils/ThemeGenerator';
-import { configure } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
 import { JoinTeamsMeeting } from './JoinTeamsMeeting';
 import { Header } from '../Header';
 import { getTeamsMeetingLink } from '../utils/GetTeamsMeetingLink';
@@ -13,14 +11,6 @@ import {
   mainJoinTeamsMeetingContainerMobileStyles,
   mainJoinTeamsMeetingContainerStyles
 } from '../styles/JoinTeamsMeeting.Styles';
-
-configure({ adapter: new Adapter() });
-
-// Disable icon warnings for tests as we don't register the icons for unit tests which causes warnings.
-// See: https://github.com/microsoft/fluentui/wiki/Using-icons#test-scenarios
-setIconOptions({
-  disableWarnings: true
-});
 
 const validTeamsMeetingLink = getTeamsMeetingLink(
   '?meetingURL=https%3A%2F%2Fteams.microsoft.com%2Fl%2Fmeetup-join%2F19%253ameeting_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA%2540thread.v2%2F0%3Fcontext%3D%257b%2522Tid%2522%253a%252200000000-0000-0000-0000-000000000000%2522%252c%2522Oid%2522%253a%252200000000-0000-0000-0000-000000000000%2522%257d'

--- a/client/src/components/MeetingExperience.test.tsx
+++ b/client/src/components/MeetingExperience.test.tsx
@@ -5,9 +5,7 @@ import {
   CallWithChatComposite,
   createAzureCommunicationCallWithChatAdapterFromClients
 } from '@azure/communication-react';
-import { setIconOptions } from '@fluentui/react';
-import { configure, mount } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import { mount } from 'enzyme';
 import { MeetingExperience, MeetingExperienceProps } from './MeetingExperience';
 import * as GetTeamsMeetingLink from '../utils/GetTeamsMeetingLink';
 import {
@@ -18,15 +16,7 @@ import {
   runFakeTimers
 } from '../utils/TestUtils';
 import { PostCallConfig } from '../models/ConfigModel';
-import { Survey } from './postcall/Survey';
-
-configure({ adapter: new Adapter() });
-
-// Disable icon warnings for tests as we don't register the icons for unit tests which causes warnings.
-// See: https://github.com/microsoft/fluentui/wiki/Using-icons#test-scenarios
-setIconOptions({
-  disableWarnings: true
-});
+import { Survey } from './PostCall/Survey';
 
 jest.mock('@azure/communication-react', () => {
   return {

--- a/client/src/components/MeetingExperience.test.tsx
+++ b/client/src/components/MeetingExperience.test.tsx
@@ -16,7 +16,7 @@ import {
   runFakeTimers
 } from '../utils/TestUtils';
 import { PostCallConfig } from '../models/ConfigModel';
-import { Survey } from './PostCall/Survey';
+import { Survey } from './postcall/Survey';
 
 jest.mock('@azure/communication-react', () => {
   return {

--- a/client/src/components/MeetingExperience.tsx
+++ b/client/src/components/MeetingExperience.tsx
@@ -19,7 +19,7 @@ import { getChatThreadIdFromTeamsLink } from '../utils/GetTeamsMeetingLink';
 import { fullSizeStyles } from '../styles/Common.styles';
 import { callWithChatComponentStyles, meetingExperienceLogoStyles } from '../styles/MeetingExperience.styles';
 import { createStubChatClient } from '../utils/stubs/chat';
-import { Survey } from './postcall/Survey';
+import { Survey } from './PostCall/Survey';
 
 import { PostCallConfig } from '../models/ConfigModel';
 export interface MeetingExperienceProps {

--- a/client/src/components/MeetingExperience.tsx
+++ b/client/src/components/MeetingExperience.tsx
@@ -19,7 +19,7 @@ import { getChatThreadIdFromTeamsLink } from '../utils/GetTeamsMeetingLink';
 import { fullSizeStyles } from '../styles/Common.styles';
 import { callWithChatComponentStyles, meetingExperienceLogoStyles } from '../styles/MeetingExperience.styles';
 import { createStubChatClient } from '../utils/stubs/chat';
-import { Survey } from './PostCall/Survey';
+import { Survey } from './postcall/Survey';
 
 import { PostCallConfig } from '../models/ConfigModel';
 export interface MeetingExperienceProps {

--- a/client/src/components/postcall/OneQuestionPollInput.test.tsx
+++ b/client/src/components/postcall/OneQuestionPollInput.test.tsx
@@ -1,16 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 import { OneQuestionPollInput, OneQuestionPollInputProps } from './OneQuestionPollInput';
-import { configure, mount } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
-import { IconButton, Rating, setIconOptions, TextField } from '@fluentui/react';
+import { mount } from 'enzyme';
+import { IconButton, Rating, TextField } from '@fluentui/react';
 
-configure({ adapter: new Adapter() });
-// Disable icon warnings for tests as we don't register the icons for unit tests which causes warnings.
-// See: https://github.com/microsoft/fluentui/wiki/Using-icons#test-scenarios
-setIconOptions({
-  disableWarnings: true
-});
 describe('OneQuestionPollInput', () => {
   it('should trigger setPollResponse when like selected', async () => {
     const mockPollType = 'likeOrDislike';

--- a/client/src/components/postcall/PostCallOneQuestionPoll.test.tsx
+++ b/client/src/components/postcall/PostCallOneQuestionPoll.test.tsx
@@ -2,19 +2,12 @@
 // Licensed under the MIT license.
 
 import { PostCallOneQuestionPollProps, PostCallOneQuestionPoll } from './PostCallOneQuestionPoll';
-import { configure, mount } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import { mount } from 'enzyme';
 import { Theme } from '@fluentui/theme';
-import { getTheme, IconButton, Rating, setIconOptions, TextField, PrimaryButton, Spinner } from '@fluentui/react';
+import { getTheme, IconButton, Rating, TextField, PrimaryButton, Spinner } from '@fluentui/react';
 import { OneQuestionPollOptions } from '../../models/ConfigModel';
 import * as PostCallUtil from '../../utils/PostCallUtil';
 
-// Disable icon warnings for tests as we don't register the icons for unit tests which causes warnings.
-// See: https://github.com/microsoft/fluentui/wiki/Using-icons#test-scenarios
-setIconOptions({
-  disableWarnings: true
-});
-configure({ adapter: new Adapter() });
 const mockAcsUserId = 'mockAcsUserId';
 const mockCallId = 'mockCallId';
 const mockMeetingLink = 'mockMeetingLink';

--- a/client/src/setupTests.js
+++ b/client/src/setupTests.js
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import { setIconOptions } from '@fluentui/react';
+
+configure({ adapter: new Adapter() });
+
+// Disable icon warnings for tests as we don't register the icons for unit tests which causes warnings.
+// See: https://github.com/microsoft/fluentui/wiki/Using-icons#test-scenarios
+setIconOptions({
+  disableWarnings: true
+});

--- a/client/src/utils/Constants.ts
+++ b/client/src/utils/Constants.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export const BOOKINGS_README_URL = 'https://aka.ms/virtual-appointments-sample-bookings';
+export const BOOKINGS_SPECIMEN_URL =
+  'https://microsoftbookings.azurewebsites.net/?organization=financialservices&UICulture=en-US';


### PR DESCRIPTION
# What

<!--- Describe your changes. -->
![2022-11-18 11_31_20-Book and 21 more pages - Work - Microsoft​ Edge](https://user-images.githubusercontent.com/43504546/202787255-3e37813c-3032-4614-afa9-6128a73f890a.png)

- Add Warning banner if using specimen Bookings page
- Refactor test configuration so that common setup steps are done outside of the tests themselves. Avoids copy/paste of common code.

# Why

The specimen Bookings page is for demonstration purposes only and it does not create appointments and send reminders.

# How Tested

<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) documentation.

**Does this PR contain ARM Template changes?**
<!--- If the PR has ARM Template changes check the boxes that apply. -->

- [ ] I have verified deploying using the ARM Template
- [ ] I have tested the deployed app end to end

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->
