### PR TITLE
Fix to enable Waffle Menu when MSBookings link is empty

### DIFF
--- a/client/src/Book.tsx
+++ b/client/src/Book.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Spinner, Stack, ThemeProvider } from '@fluentui/react';
+import { LayerHost, Spinner, Stack, ThemeProvider } from '@fluentui/react';
 import { backgroundStyles, fullSizeStyles } from './styles/Common.styles';
 import { Header } from './Header';
 import './styles/Common.css';
@@ -37,7 +37,15 @@ export const Book = (): JSX.Element => {
       <ThemeProvider theme={config.theme} style={{ height: '100%' }}>
         <Stack styles={backgroundStyles(config.theme)}>
           <Header companyName={config.companyName} parentid={PARENT_ID} />
-          {config.microsoftBookingsUrl ? <BookingsPage config={config} /> : <NoSchedulingPage config={config} />}
+          <LayerHost
+            id={PARENT_ID}
+            style={{
+              position: 'relative',
+              height: '100%'
+            }}
+          >
+            {config.microsoftBookingsUrl ? <BookingsPage config={config} /> : <NoSchedulingPage config={config} />}
+          </LayerHost>
         </Stack>
       </ThemeProvider>
     );

--- a/client/src/__snapshots__/Book.test.tsx.snap
+++ b/client/src/__snapshots__/Book.test.tsx.snap
@@ -53,83 +53,94 @@ exports[`Book should match snapshot when bookings link is empty 1`] = `
       </span>
     </div>
     <div
-      className="ms-Stack css-129"
+      className="ms-LayerHost"
+      id="BookMeetingSection"
+      style={
+        Object {
+          "height": "100%",
+          "position": "relative",
+        }
+      }
     >
       <div
-        className="ms-Stack css-130"
+        className="ms-Stack css-129"
       >
         <div
-          className="ms-Stack css-131"
+          className="ms-Stack css-130"
         >
-          <span
-            className="css-132"
-          >
-            No scheduling configured
-          </span>
-          <span
-            className="css-133"
-          >
-            This sample does not have a Microsoft Bookings page configured.
-          </span>
-          <span
-            className="css-134"
-          >
-            Frequently asked questions
-          </span>
           <div
-            className="ms-Stack css-135"
+            className="ms-Stack css-131"
           >
-            <a
-              className="ms-Link root-136"
-              href="https://aka.ms/virtual-appointments-sample-bookings"
-              onClick={[Function]}
-              tabIndex={0}
-              target="_blank"
+            <span
+              className="css-132"
             >
-              <div
-                className="ms-Stack css-137"
+              No scheduling configured
+            </span>
+            <span
+              className="css-133"
+            >
+              This sample does not have a Microsoft Bookings page configured.
+            </span>
+            <span
+              className="css-134"
+            >
+              Frequently asked questions
+            </span>
+            <div
+              className="ms-Stack css-135"
+            >
+              <a
+                className="ms-Link root-136"
+                href="https://aka.ms/virtual-appointments-sample-bookings"
+                onClick={[Function]}
+                tabIndex={0}
+                target="_blank"
               >
                 <div
-                  className="ms-StackItem css-138"
-                  style={
-                    Object {
-                      "fontSize": ".9375rem",
-                      "fontWeight": "400",
-                      "letterSpacing": "-0.015rem",
-                      "lineHeight": "1rem",
-                      "paddingRight": ".5rem",
-                      "textDecoration": "underline",
-                      "verticalAlign": "bottom",
-                    }
-                  }
+                  className="ms-Stack css-137"
                 >
-                  How do I change my Microsoft Bookings page URL?
-                </div>
-                <div
-                  className="ms-StackItem css-138"
-                  style={
-                    Object {
-                      "textDecoration": "none",
-                    }
-                  }
-                >
-                  <span
+                  <div
+                    className="ms-StackItem css-138"
                     style={
                       Object {
-                        "alignItems": "center",
-                        "display": "flex",
+                        "fontSize": ".9375rem",
+                        "fontWeight": "400",
+                        "letterSpacing": "-0.015rem",
+                        "lineHeight": "1rem",
+                        "paddingRight": ".5rem",
+                        "textDecoration": "underline",
+                        "verticalAlign": "bottom",
                       }
                     }
                   >
-                    <i
-                      aria-hidden={true}
-                      className="root-105"
-                      data-icon-name="OpenInNewWindow"
-                    />
-                  </span>
+                    How do I change my Microsoft Bookings page URL?
+                  </div>
+                  <div
+                    className="ms-StackItem css-138"
+                    style={
+                      Object {
+                        "textDecoration": "none",
+                      }
+                    }
+                  >
+                    <span
+                      style={
+                        Object {
+                          "alignItems": "center",
+                          "display": "flex",
+                        }
+                      }
+                    >
+                      <i
+                        aria-hidden={true}
+                        className="root-105"
+                        data-icon-name="OpenInNewWindow"
+                      />
+                    </span>
+                  </div>
                 </div>
-              </div>
-            </a>
+              </a>
+            </div>
           </div>
         </div>
       </div>

--- a/client/src/components/Book/BookingsPage.tsx
+++ b/client/src/components/Book/BookingsPage.tsx
@@ -1,13 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { LayerHost } from '@fluentui/react';
 import { BOOKINGS_SPECIMEN_URL } from '../../utils/Constants';
 import WarningBanner from './WarningBanner';
 import { AppConfigModel } from '../../models/ConfigModel';
 import { embededIframeStyles } from '../../styles/Book.styles';
-
-const PARENT_ID = 'BookMeetingSection';
 
 interface BookingsPageProps {
   config: AppConfigModel;
@@ -15,15 +12,9 @@ interface BookingsPageProps {
 
 export const BookingsPage = (props: BookingsPageProps): JSX.Element => {
   return (
-    <LayerHost
-      id={PARENT_ID}
-      style={{
-        position: 'relative',
-        height: '100%'
-      }}
-    >
+    <>
       {props.config.microsoftBookingsUrl === BOOKINGS_SPECIMEN_URL ? <WarningBanner /> : <></>}
       <iframe src={props.config.microsoftBookingsUrl} scrolling="yes" style={embededIframeStyles}></iframe>
-    </LayerHost>
+    </>
   );
 };

--- a/e2e-tests/tests/book.spec.ts
+++ b/e2e-tests/tests/book.spec.ts
@@ -19,4 +19,13 @@ test.describe("tests:", () => {
       page.locator('[id="BookMeetingSection"]').first()
     ).toBeVisible();
   });
+
+  test("navigating to visit using waffle menu", async ({ page }) => {
+    const waffle = page.locator('[data-icon-name="Waffle"]').first();
+    await waffle.click();
+
+    // Click text=Visit
+    await page.locator("text=Visit").click();
+    await expect(page).toHaveURL("http://localhost:8080/visit");
+  });
 });


### PR DESCRIPTION
# What

Fix to show the waffle menu on click when MSbookings link is empty and "no scheduling" page is shown
Added e2e test to test load, click and navigation of Waffle menu from /book to /visit

# Why
Waffle menu was not popping out

# How Tested
on local and deployed to personal Azure subscriptions
![image](https://user-images.githubusercontent.com/100614160/204370084-2c9cd2cd-be63-446d-a776-2d7e6f163696.png)

![image](https://user-images.githubusercontent.com/100614160/204406038-6bd54082-2772-4cad-a656-7ac89f5838d3.png)


**Does this PR contain ARM Template changes?**
NO

**Is this a breaking change?**
NO
