### PR TITLE
Invite Participant Url for presenter

### DIFF
--- a/client/src/Visit.test.tsx
+++ b/client/src/Visit.test.tsx
@@ -82,8 +82,12 @@ describe('Visit', () => {
     fetchRoomsResponseSpy.mockReturnValue(
       Promise.resolve({
         participant: {
-          id: 'mockParticipantId',
+          id: 'mockPresenterId',
           role: RoomParticipantRole.presenter
+        },
+        invitee: {
+          id: 'mockAttendeeId',
+          role: RoomParticipantRole.attendee
         },
         token: 'token'
       })

--- a/client/src/components/JoinTeamsMeeting.tsx
+++ b/client/src/components/JoinTeamsMeeting.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { Stack, TextField, PrimaryButton, LayerHost, Theme, ThemeContext, createTheme } from '@fluentui/react';
 import { Header } from '../Header';
 import { AppConfigModel } from '../models/ConfigModel';
-import { getCurrentMeetingURL, isValidTeamsLink, makeJoinUrl } from '../utils/GetMeetingLink';
+import { getCurrentMeetingURL, isValidTeamsLink, makeTeamsJoinUrl } from '../utils/GetMeetingLink';
 import { backgroundStyles } from '../styles/Common.styles';
 import {
   makeJoinTeamsLayerHostStyles,
@@ -53,7 +53,7 @@ export class JoinTeamsMeeting extends React.Component<JoinTeamsMeetingProps, Joi
   }
 
   render(): JSX.Element {
-    const link = makeJoinUrl(this.state.teamsMeetingLink);
+    const link = makeTeamsJoinUrl(this.state.teamsMeetingLink);
     const enableButton = isValidTeamsLink(this.state.teamsMeetingLink);
     const parentID = 'JoinTeamsMeetingSection';
 

--- a/client/src/components/__mocks__/MeetingExperience.tsx
+++ b/client/src/components/__mocks__/MeetingExperience.tsx
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { TeamsMeetingExperienceProps } from '../teams/TeamsMeetingExperience';
+
+export const TeamsMeetingExperience = (props: TeamsMeetingExperienceProps): JSX.Element => {
+  return <></>;
+};

--- a/client/src/components/__mocks__/MeetingExperience.tsx
+++ b/client/src/components/__mocks__/MeetingExperience.tsx
@@ -1,8 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
-
-import { TeamsMeetingExperienceProps } from '../teams/TeamsMeetingExperience';
-
-export const TeamsMeetingExperience = (props: TeamsMeetingExperienceProps): JSX.Element => {
-  return <></>;
-};

--- a/client/src/components/rooms/RoomsMeeting.test.tsx
+++ b/client/src/components/rooms/RoomsMeeting.test.tsx
@@ -103,8 +103,9 @@ describe('RoomsMeeting', () => {
     roomsMeeting.update();
     const spinners = roomsMeeting.find(Spinner);
     const roomsMeetingExperience = roomsMeeting.find(RoomsMeetingExperience);
-    expect(roomsMeetingExperience.props().roomsInfo.inviteParticipantUrl).toBeDefined;
-    console.log(roomsMeetingExperience.props().roomsInfo.inviteParticipantUrl);
+    const inviteLink = roomsMeetingExperience.props().roomsInfo.inviteParticipantUrl;
+    expect(inviteLink).toBeDefined;
+    expect(inviteLink).toContain('/visit?roomId=mockRoomId&userId=mockAttendeeId');
     expect(spinners.length).toBe(0);
     expect(roomsMeetingExperience.length).toBe(1);
   });

--- a/client/src/components/rooms/RoomsMeeting.test.tsx
+++ b/client/src/components/rooms/RoomsMeeting.test.tsx
@@ -104,7 +104,7 @@ describe('RoomsMeeting', () => {
     const spinners = roomsMeeting.find(Spinner);
     const roomsMeetingExperience = roomsMeeting.find(RoomsMeetingExperience);
     const inviteLink = roomsMeetingExperience.props().roomsInfo.inviteParticipantUrl;
-    expect(inviteLink).toBeDefined;
+    expect(inviteLink).toBeDefined();
     expect(inviteLink).toContain('/visit?roomId=mockRoomId&userId=mockAttendeeId');
     expect(spinners.length).toBe(0);
     expect(roomsMeetingExperience.length).toBe(1);
@@ -130,7 +130,7 @@ describe('RoomsMeeting', () => {
     roomsMeeting.update();
     const spinners = roomsMeeting.find(Spinner);
     const roomsMeetingExperience = roomsMeeting.find(RoomsMeetingExperience);
-    expect(roomsMeetingExperience.props().roomsInfo.inviteParticipantUrl).toBeUndefined;
+    expect(roomsMeetingExperience.props().roomsInfo.inviteParticipantUrl).toBeUndefined();
     expect(spinners.length).toBe(0);
     expect(roomsMeetingExperience.length).toBe(1);
   });

--- a/client/src/components/rooms/RoomsMeeting.test.tsx
+++ b/client/src/components/rooms/RoomsMeeting.test.tsx
@@ -79,19 +79,23 @@ describe('RoomsMeeting', () => {
     expect(roomsMeetingExperience.length).toBe(0);
   });
 
-  it('should render RoomsMeetingExperience when rooms response is loaded', async () => {
+  it('should render RoomsMeetingExperience with invite link when rooms response is loaded for presenter', async () => {
     const fetchRoomsResponseSpy = jest.spyOn(FetchRoomsResponse, 'fetchRoomsResponse');
     fetchRoomsResponseSpy.mockReturnValue(
       Promise.resolve({
         participant: {
-          id: 'mockParticipantId',
+          id: 'mockPresenterId',
           role: RoomParticipantRole.presenter
+        },
+        invitee: {
+          id: 'mockAttendeeId',
+          role: RoomParticipantRole.attendee
         },
         token: 'token'
       })
     );
     const roomsMeeting = mount(
-      <RoomsMeeting locator={roomCallLocator} participantId={'mockParticipantId'} onDisplayError={jest.fn()} />
+      <RoomsMeeting locator={roomCallLocator} participantId={'mockPresenterId'} onDisplayError={jest.fn()} />
     );
 
     await runFakeTimers();
@@ -99,6 +103,33 @@ describe('RoomsMeeting', () => {
     roomsMeeting.update();
     const spinners = roomsMeeting.find(Spinner);
     const roomsMeetingExperience = roomsMeeting.find(RoomsMeetingExperience);
+    expect(roomsMeetingExperience.props().roomsInfo.inviteParticipantUrl).toBeDefined;
+    console.log(roomsMeetingExperience.props().roomsInfo.inviteParticipantUrl);
+    expect(spinners.length).toBe(0);
+    expect(roomsMeetingExperience.length).toBe(1);
+  });
+
+  it('should render RoomsMeetingExperience without invite link when rooms response is loaded for attendee', async () => {
+    const fetchRoomsResponseSpy = jest.spyOn(FetchRoomsResponse, 'fetchRoomsResponse');
+    fetchRoomsResponseSpy.mockReturnValue(
+      Promise.resolve({
+        participant: {
+          id: 'mockAttendeeId',
+          role: RoomParticipantRole.attendee
+        },
+        token: 'token'
+      })
+    );
+    const roomsMeeting = mount(
+      <RoomsMeeting locator={roomCallLocator} participantId={'mockAttendeeId'} onDisplayError={jest.fn()} />
+    );
+
+    await runFakeTimers();
+
+    roomsMeeting.update();
+    const spinners = roomsMeeting.find(Spinner);
+    const roomsMeetingExperience = roomsMeeting.find(RoomsMeetingExperience);
+    expect(roomsMeetingExperience.props().roomsInfo.inviteParticipantUrl).toBeUndefined;
     expect(spinners.length).toBe(0);
     expect(roomsMeetingExperience.length).toBe(1);
   });

--- a/client/src/components/rooms/RoomsMeeting.tsx
+++ b/client/src/components/rooms/RoomsMeeting.tsx
@@ -23,7 +23,7 @@ export const RoomsMeeting = (props: RoomsMeetingProps): JSX.Element => {
   const [inviteUrl, setInviteUrl] = useState<string | undefined>(undefined);
 
   const formInviteUrl = (participantId: string): string => {
-    return window.location.href + `?roomId=${locator.roomId}&userId=${participantId}`;
+    return window.location.origin + `/visit?roomId=${locator.roomId}&userId=${participantId}`;
   };
 
   useEffect(() => {

--- a/client/src/components/rooms/RoomsMeeting.tsx
+++ b/client/src/components/rooms/RoomsMeeting.tsx
@@ -20,6 +20,12 @@ export const RoomsMeeting = (props: RoomsMeetingProps): JSX.Element => {
 
   const [roomsToken, setRoomsToken] = useState<string | undefined>(undefined);
   const [userRole, setUserRole] = useState<RoomParticipantRole | undefined>(undefined);
+  const [inviteUrl, setInviteUrl] = useState<string | undefined>(undefined);
+
+  const formInviteUrl = (participantId: string): string => {
+    return window.location.href + `?roomId=${locator.roomId}&userId=${participantId}`;
+  };
+
   useEffect(() => {
     const fetchData = async (): Promise<void> => {
       try {
@@ -27,6 +33,7 @@ export const RoomsMeeting = (props: RoomsMeetingProps): JSX.Element => {
         if (roomsResponse) {
           setRoomsToken(roomsResponse.token);
           setUserRole(roomsResponse.participant.role);
+          if (roomsResponse.invitee) setInviteUrl(formInviteUrl(roomsResponse.invitee.id));
         }
       } catch (error) {
         console.error(error);
@@ -46,7 +53,8 @@ export const RoomsMeeting = (props: RoomsMeetingProps): JSX.Element => {
       roomsInfo={{
         userId: participantId,
         userRole: userRole,
-        locator: locator
+        locator: locator,
+        inviteParticipantUrl: inviteUrl
       }}
       token={roomsToken}
       onDisplayError={(error) => onDisplayError(error)}

--- a/client/src/components/rooms/RoomsMeeting.tsx
+++ b/client/src/components/rooms/RoomsMeeting.tsx
@@ -8,6 +8,7 @@ import { Spinner } from '@fluentui/react';
 import { fullSizeStyles } from '../../styles/Common.styles';
 import { RoomParticipantRole } from '../../models/RoomModel';
 import { RoomsMeetingExperience } from './RoomsMeetingExperience';
+import { makeRoomsJoinUrl } from '../../utils/GetMeetingLink';
 
 export interface RoomsMeetingProps {
   locator: RoomCallLocator;
@@ -23,7 +24,7 @@ export const RoomsMeeting = (props: RoomsMeetingProps): JSX.Element => {
   const [inviteUrl, setInviteUrl] = useState<string | undefined>(undefined);
 
   const formInviteUrl = (participantId: string): string => {
-    return window.location.origin + `/visit?roomId=${locator.roomId}&userId=${participantId}`;
+    return window.location.origin + makeRoomsJoinUrl(locator.roomId, participantId);
   };
 
   useEffect(() => {

--- a/client/src/components/rooms/RoomsMeetingExperience.test.tsx
+++ b/client/src/components/rooms/RoomsMeetingExperience.test.tsx
@@ -44,10 +44,10 @@ describe('RoomsMeetingExperience', () => {
         roomsInfo={{
           userId: 'userId',
           userRole: RoomParticipantRole.presenter,
-          locator: { roomId: 'roomId' }
+          locator: { roomId: 'roomId' },
+          inviteParticipantUrl: 'testUrl'
         }}
         token={'token'}
-        inviteParticipantUrl={'testUrl'}
         onDisplayError={jest.fn()}
       />
     );

--- a/client/src/components/rooms/RoomsMeetingExperience.tsx
+++ b/client/src/components/rooms/RoomsMeetingExperience.tsx
@@ -41,7 +41,7 @@ export const RoomsMeetingExperience = (props: RoomsMeetingExperienceProps): JSX.
     };
 
     _createAdapters();
-  }, [credential, locator, userId, onDisplayError]);
+  }, [credential]);
 
   if (callAdapter) {
     //TODO set forFactor to mobile

--- a/client/src/components/rooms/RoomsMeetingExperience.tsx
+++ b/client/src/components/rooms/RoomsMeetingExperience.tsx
@@ -13,7 +13,6 @@ import { RoomParticipantRole, RoomsInfo } from '../../models/RoomModel';
 export interface RoomsMeetingExperienceProps {
   roomsInfo: RoomsInfo;
   token: string;
-  inviteParticipantUrl?: string;
   onDisplayError(error: any): void;
 }
 
@@ -42,12 +41,12 @@ export const RoomsMeetingExperience = (props: RoomsMeetingExperienceProps): JSX.
     };
 
     _createAdapters();
-  }, [credential, displayName, locator, userId, onDisplayError]);
+  }, [credential, locator, userId, onDisplayError]);
 
   if (callAdapter) {
     //TODO set forFactor to mobile
     if (userRole === RoomParticipantRole.presenter) {
-      return <CallComposite adapter={callAdapter} callInvitationUrl={props.inviteParticipantUrl} />;
+      return <CallComposite adapter={callAdapter} callInvitationUrl={props.roomsInfo.inviteParticipantUrl} />;
     } else {
       return <CallComposite adapter={callAdapter} />;
     }

--- a/client/src/models/RoomModel.ts
+++ b/client/src/models/RoomModel.ts
@@ -15,12 +15,14 @@ export interface RoomParticipant {
 }
 
 export interface JoinRoomResponse {
-  participant: RoomParticipant;
   token: string;
+  participant: RoomParticipant;
+  invitee?: RoomParticipant;
 }
 
 export interface RoomsInfo {
   userId: string;
   userRole: RoomParticipantRole;
   locator: RoomCallLocator;
+  inviteParticipantUrl?: string;
 }

--- a/client/src/utils/CreateRoom.test.ts
+++ b/client/src/utils/CreateRoom.test.ts
@@ -19,6 +19,16 @@ const mockCreateRoomResponse = {
   ]
 } as CreateRoomResponse;
 
+const mockErrorResponse = {
+  roomId: 'roomId',
+  participants: [
+    {
+      id: 'presenterId',
+      role: 'Presenter'
+    }
+  ]
+} as CreateRoomResponse;
+
 describe('CreateRoomAndRedirectUrl', () => {
   it('returns rooms url with userId and roomId', async () => {
     const createRoomSpy = jest.spyOn(CreateRoom, 'createRoom');
@@ -48,6 +58,23 @@ describe('CreateRoomAndRedirectUrl', () => {
       await createRoomAndRedirectUrl(mockUserRole);
     } catch (err) {
       expect(err).toBeDefined();
+    }
+  });
+
+  it('throws error if no userId with given role is present in the room created', async () => {
+    const createRoomSpy = jest.spyOn(CreateRoom, 'createRoom');
+    createRoomSpy.mockImplementation(
+      async (): Promise<CreateRoomResponse> => {
+        return mockErrorResponse;
+      }
+    );
+
+    const mockUserRole = 'Attendee';
+    try {
+      await createRoomAndRedirectUrl(mockUserRole);
+    } catch (err) {
+      expect(err).toBeDefined();
+      expect((err as Error).message).toBe('room does not have participant with role Attendee');
     }
   });
 });

--- a/client/src/utils/CreateRoom.ts
+++ b/client/src/utils/CreateRoom.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 import { RoomParticipant, RoomParticipantRole } from '../models/RoomModel';
 import { createRoom } from './FetchRoomsResponse';
+import { makeRoomsJoinUrl } from './GetMeetingLink';
 
 export const createRoomAndRedirectUrl = async (userRole: string): Promise<string> => {
   let redirectUrl: string;
@@ -11,7 +12,8 @@ export const createRoomAndRedirectUrl = async (userRole: string): Promise<string
     const userId = roomResponse.participants.find(
       (participant: RoomParticipant) => (participant.role as RoomParticipantRole) === userRole
     )?.id;
-    redirectUrl = `/visit?roomId=${roomId}&userId=${userId}`;
+    if (userId) redirectUrl = makeRoomsJoinUrl(roomId, userId);
+    else throw new Error(`room does not have participant with role ${userRole}`);
   } catch (e) {
     //EndUser to add logging errors in place of console logging below
     console.log(e);

--- a/client/src/utils/FetchRoomsResponse.test.tsx
+++ b/client/src/utils/FetchRoomsResponse.test.tsx
@@ -18,7 +18,7 @@ describe('FetchRoomsToken', () => {
   it('should fetch rooms response and return it', async () => {
     const mockRoomsResponse: JoinRoomResponse = {
       participant: {
-        id: 'mockParticipantId',
+        id: 'mockPresenterId',
         role: RoomParticipantRole.presenter
       },
       token: 'mockToken'

--- a/client/src/utils/GetMeetingLink.test.ts
+++ b/client/src/utils/GetMeetingLink.test.ts
@@ -7,7 +7,9 @@ import {
   getCurrentMeetingURL,
   getRoomCallLocator,
   getRoomsUserId,
-  getTeamsMeetingLink
+  getTeamsMeetingLink,
+  makeRoomsJoinUrl,
+  makeTeamsJoinUrl
 } from './GetMeetingLink';
 
 describe('getMeetingLink', () => {
@@ -122,5 +124,15 @@ describe('getMeetingLink', () => {
     } catch (error) {
       expect(error).toBeDefined();
     }
+  });
+
+  test('should make correct teams join url', () => {
+    const result = makeTeamsJoinUrl('mockTeamsMeetingUrl');
+    expect(result).toBe('?meetingURL=mockTeamsMeetingUrl');
+  });
+
+  test('should make correct rooms join url', () => {
+    const result = makeRoomsJoinUrl('mockRoomId', 'mockUserId');
+    expect(result).toBe('/visit?roomId=mockRoomId&userId=mockUserId');
   });
 });

--- a/client/src/utils/GetMeetingLink.ts
+++ b/client/src/utils/GetMeetingLink.ts
@@ -75,5 +75,8 @@ export const isValidTeamsLink = (teamsMeetingLink: string): boolean => {
   return true;
 };
 
-export const makeJoinUrl = (teamsMeetingLink: string): string =>
+export const makeTeamsJoinUrl = (teamsMeetingLink: string): string =>
   '?' + MEETING_URL_PARAMNAME + '=' + encodeURIComponent(teamsMeetingLink);
+
+export const makeRoomsJoinUrl = (roomId: string, userId: string): string =>
+  '/visit?roomId=' + roomId + '&userId=' + userId;

--- a/server/src/controllers/roomsController.test.ts
+++ b/server/src/controllers/roomsController.test.ts
@@ -112,7 +112,7 @@ describe('roomsController', () => {
   });
 
   describe('test getToken', () => {
-    test('Should send expected response', async () => {
+    test('Should send expected response if called for a presenter', async () => {
       const mockedBody = {
         roomId: expectedRoomId,
         userId: expectedPresenterId
@@ -146,6 +146,53 @@ describe('roomsController', () => {
         participant: {
           id: expectedPresenterId,
           role: RoomParticipantRole.presenter
+        },
+        invitee: {
+          id: expectedAttendeeId,
+          role: RoomParticipantRole.attendee
+        }
+      };
+
+      await getToken(mockedIdentityClient, mockedRoomsClient)(request, response, next);
+
+      expect(response.send).toHaveBeenCalled();
+      expect(response.send).toHaveBeenCalledWith(expectedResponse);
+    });
+
+    test('Should send expected response if called for a attendee', async () => {
+      const mockedBody = {
+        roomId: expectedRoomId,
+        userId: expectedAttendeeId
+      };
+
+      const request: any = { body: mockedBody };
+
+      const mockedIdentityClient = {
+        getToken: async (_user, _scopes) => ({ token: expectedToken })
+      } as CommunicationIdentityClient;
+
+      const mockedRoomsClient = {
+        getParticipants: async (_roomId) => [
+          {
+            id: {
+              communicationUserId: expectedPresenterId
+            },
+            role: RoomParticipantRole.presenter
+          },
+          {
+            id: {
+              communicationUserId: expectedAttendeeId
+            },
+            role: RoomParticipantRole.attendee
+          }
+        ]
+      } as RoomsClient;
+
+      const expectedResponse = {
+        token: expectedToken,
+        participant: {
+          id: expectedAttendeeId,
+          role: RoomParticipantRole.attendee
         }
       };
 

--- a/server/src/controllers/roomsController.ts
+++ b/server/src/controllers/roomsController.ts
@@ -89,6 +89,20 @@ export const getToken = (identityClient: CommunicationIdentityClient, roomsClien
       return res.status(404).send(ERROR_NO_USER_FOUND_IN_ROOM);
     }
 
+    let invitee: TestAppointmentRoomParticipant | undefined;
+
+    if (foundUserParticipant.role === RoomParticipantRole.presenter) {
+      const attendee = participantsList.find(
+        (participant: RoomParticipant) => (participant.id as CommunicationUserIdentifier).communicationUserId !== userId
+      );
+      if (attendee) {
+        invitee = {
+          id: (attendee.id as CommunicationUserIdentifier).communicationUserId,
+          role: attendee.role as RoomParticipantRole
+        };
+      }
+    }
+
     // Create token
     const scopes: TokenScope[] = ['voip'];
     const user: CommunicationUserIdentifier = {
@@ -103,6 +117,7 @@ export const getToken = (identityClient: CommunicationIdentityClient, roomsClien
         id: (foundUserParticipant.id as CommunicationUserIdentifier).communicationUserId,
         role: foundUserParticipant.role as RoomParticipantRole
       },
+      invitee: invitee,
       token: tokenResponse.token
     };
 

--- a/server/src/models/roomModel.ts
+++ b/server/src/models/roomModel.ts
@@ -23,6 +23,7 @@ export interface JoinRoomRequest {
 }
 
 export interface JoinRoomResponse {
-  participant: RoomParticipant;
   token: string;
+  participant: RoomParticipant;
+  invitee?: RoomParticipant;
 }


### PR DESCRIPTION
# What

API changes:
/token api will now return 
`{
     token: <user token>,
     participant: {
        id: <userId>,
        role: "presenter"
       },
     invitee: {
        id: <userId>,
        role: "attendee"
      }
}`

in case of presenter 
and will return 

`{
     token: <user token>,
     participant: {
        id: <userId>,
        role: "presenter"
       }
}`

If the user joining the call is presenter, he will have a "copy invite link" option in the "Add people" section

# Why

Presenter will be able to invite attendees using the copy invite link
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
Client UTs
<img width="538" alt="image" src="https://user-images.githubusercontent.com/99863251/205742190-0289195b-ffba-4c8a-a8c9-dd4d31bf1c28.png">
Presenter has the copy invite link: 
<img width="963" alt="image" src="https://user-images.githubusercontent.com/99863251/205742475-ed1ec8fa-5991-4a2d-83af-3d1751d5eccc.png">
Can be tested using : https://1qp-appservice.azurewebsites.net

<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) documentation.

**Does this PR contain ARM Template changes?**
<!--- If the PR has ARM Template changes check the boxes that apply. -->

- [ ] I have verified deploying using the ARM Template
- [ ] I have tested the deployed app end to end

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->
