### PR TITLE
Set postCall to undefined if unable to initialize CosmosDb and postCall is onequestionpoll

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -50,7 +50,7 @@ if (surveyDBHandler) {
   surveyDBHandler.init();
 
   app.post('/api/surveyResults', storeSurveyResult(surveyDBHandler));
-} else {
+} else if (config.postCall && config.postCall.survey.type === 'onequestionpoll') {
   config.postCall = undefined;
 }
 


### PR DESCRIPTION
# What

Only set postCall to undefined if unable to initialize Cosmos and post Call type is onequestionpoll

# Why

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested

Set postCall to msforms, custom, and onequestionpoll.

# Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) documentation.

**Does this PR contain ARM Template changes?**
<!--- If the PR has ARM Template changes check the boxes that apply. -->

- [ ] I have verified deploying using the ARM Template
- [ ] I have tested the deployed app end to end

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->
