### PR TITLE
Toggle ScreenShare button based on config

### DIFF
--- a/client/src/components/teams/TeamsMeeting.tsx
+++ b/client/src/components/teams/TeamsMeeting.tsx
@@ -50,6 +50,7 @@ export const TeamsMeeting = (props: TeamsMeetingProps): JSX.Element => {
       waitingTitle={config.waitingTitle}
       waitingSubtitle={config.waitingSubtitle}
       chatEnabled={config.chatEnabled}
+      screenShareEnabled={config.screenShareEnabled}
       postCall={config.postCall}
       onDisplayError={(error) => onDisplayError(error)}
     />

--- a/client/src/components/teams/TeamsMeetingExperience.test.tsx
+++ b/client/src/components/teams/TeamsMeetingExperience.test.tsx
@@ -185,9 +185,11 @@ describe('TeamsMeetingExperience', () => {
       expect(callOptions?.chatButton).toBe(chatEnabled);
       expect(callOptions?.screenShareButton).toBe(screenShareEnabled);
 
-      const icons = composite.props().icons as CallWithChatCompositeIcons;
-      expect(icons.LobbyScreenWaitingToBeAdmitted).toBe(logoUrl);
-      expect(icons.LobbyScreenConnectingToCall).toBe(logoUrl);
+      const lobbyScreenWaitingToBeAdmitted = composite.props().icons?.LobbyScreenWaitingToBeAdmitted;
+      expect(lobbyScreenWaitingToBeAdmitted?.props().src).toBe(logoUrl);
+
+      const lobbyScreenConnectingToCall = composite.props().icons?.LobbyScreenConnectingToCall;
+      expect(lobbyScreenConnectingToCall?.props().src).toBe(logoUrl);
 
       const locale = composite.props().locale as CompositeLocale;
       expect(locale.strings.call.lobbyScreenWaitingToBeAdmittedTitle).toBe(lobbyTitle);

--- a/client/src/components/teams/TeamsMeetingExperience.test.tsx
+++ b/client/src/components/teams/TeamsMeetingExperience.test.tsx
@@ -48,10 +48,6 @@ const mockPostCall: PostCallConfig = {
   }
 };
 
-afterEach(() => {
-  jest.clearAllMocks();
-});
-
 describe('TeamsMeetingExperience', () => {
   const waitingTitle = 'waiting title';
   const waitingSubtitle = 'waiting subtitle';
@@ -63,6 +59,10 @@ describe('TeamsMeetingExperience', () => {
     jest.spyOn(console, 'error').mockImplementation();
     const getChatThreadIdFromTeamsLinkSpy = jest.spyOn(GetTeamsMeetingLink, 'getChatThreadIdFromTeamsLink');
     getChatThreadIdFromTeamsLinkSpy.mockReturnValue('threadId');
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
   });
 
   it('should pass props for customizing the lobby experience to the CallWithChatComposite', async () => {
@@ -138,24 +138,20 @@ describe('TeamsMeetingExperience', () => {
     expect(callWithChatComposites.first().props().formFactor).toEqual('mobile');
   });
 
-  it.each([
-    [true, true],
-    [true, false],
-    [false, true],
-    [false, false]
-  ])(
+  it.each([[true], [false]])(
     'should pass the call settings to CallWithChatComposite as props',
-    async (chatEnabled: boolean, screenShareEnabled: boolean) => {
+    async (screenShareEnabled: boolean) => {
       (createAzureCommunicationCallWithChatAdapterFromClients as jest.Mock).mockImplementationOnce(() =>
         createMockCallWithChatAdapter()
       );
 
       const theme = generateTheme('#F18472');
+      const chatEnabled = true;
       const lobbyTitle = 'myLobbyTitle';
       const lobbySubtitle = 'myLobbySubtitle';
       const logoUrl = 'myLogoUrl';
 
-      const meetingExperience = mount<TeamsMeetingExperienceProps>(
+      const meetingExperience = await mount<TeamsMeetingExperienceProps>(
         <TeamsMeetingExperience
           userId={{ communicationUserId: 'test' }}
           token={'token'}
@@ -168,7 +164,7 @@ describe('TeamsMeetingExperience', () => {
           logoUrl={logoUrl}
           chatEnabled={chatEnabled}
           screenShareEnabled={screenShareEnabled}
-          postCall={mockPostCall}
+          postCall={undefined}
           onDisplayError={jest.fn()}
         />
       );

--- a/client/src/components/teams/TeamsMeetingExperience.test.tsx
+++ b/client/src/components/teams/TeamsMeetingExperience.test.tsx
@@ -3,7 +3,6 @@
 
 import {
   CallWithChatComposite,
-  CallWithChatCompositeIcons,
   CallWithChatControlOptions,
   CompositeLocale,
   createAzureCommunicationCallWithChatAdapterFromClients

--- a/client/src/components/teams/TeamsMeetingExperience.test.tsx
+++ b/client/src/components/teams/TeamsMeetingExperience.test.tsx
@@ -3,6 +3,9 @@
 
 import {
   CallWithChatComposite,
+  CallWithChatCompositeIcons,
+  CallWithChatControlOptions,
+  CompositeLocale,
   createAzureCommunicationCallWithChatAdapterFromClients
 } from '@azure/communication-react';
 import { mount } from 'enzyme';
@@ -17,6 +20,7 @@ import {
 } from '../../utils/TestUtils';
 import { PostCallConfig } from '../../models/ConfigModel';
 import { Survey } from '../postcall/Survey';
+import { generateTheme } from '../../utils/ThemeGenerator';
 
 jest.mock('@azure/communication-react', () => {
   return {
@@ -79,6 +83,7 @@ describe('TeamsMeetingExperience', () => {
         waitingSubtitle={waitingSubtitle}
         logoUrl={logoUrl}
         chatEnabled={true}
+        screenShareEnabled={true}
         postCall={mockPostCall}
         onDisplayError={jest.fn()}
       />
@@ -119,6 +124,7 @@ describe('TeamsMeetingExperience', () => {
         waitingSubtitle={waitingSubtitle}
         logoUrl={logoUrl}
         chatEnabled={true}
+        screenShareEnabled={true}
         postCall={mockPostCall}
         onDisplayError={jest.fn()}
       />
@@ -132,6 +138,62 @@ describe('TeamsMeetingExperience', () => {
     expect(callWithChatComposites.length).toBe(1);
     expect(callWithChatComposites.first().props().formFactor).toEqual('mobile');
   });
+
+  it.each([
+    [true, true],
+    [true, false],
+    [false, true],
+    [false, false]
+  ])(
+    'should pass the call settings to CallWithChatComposite as props',
+    async (chatEnabled: boolean, screenShareEnabled: boolean) => {
+      (createAzureCommunicationCallWithChatAdapterFromClients as jest.Mock).mockImplementationOnce(() =>
+        createMockCallWithChatAdapter()
+      );
+
+      const theme = generateTheme('#F18472');
+      const lobbyTitle = 'myLobbyTitle';
+      const lobbySubtitle = 'myLobbySubtitle';
+      const logoUrl = 'myLogoUrl';
+
+      const meetingExperience = mount<TeamsMeetingExperienceProps>(
+        <TeamsMeetingExperience
+          userId={{ communicationUserId: 'test' }}
+          token={'token'}
+          displayName={'name'}
+          endpointUrl={'endpoint'}
+          locator={{ meetingLink: 'meeting link' }}
+          fluentTheme={theme}
+          waitingTitle={lobbyTitle}
+          waitingSubtitle={lobbySubtitle}
+          logoUrl={logoUrl}
+          chatEnabled={chatEnabled}
+          screenShareEnabled={screenShareEnabled}
+          postCall={mockPostCall}
+          onDisplayError={jest.fn()}
+        />
+      );
+
+      await runFakeTimers();
+      meetingExperience.update();
+
+      const callWithChatComposites = meetingExperience.find(CallWithChatComposite);
+      expect(callWithChatComposites.length).toBe(1);
+
+      const composite = callWithChatComposites.first();
+      const callOptions = composite.props().options?.callControls as CallWithChatControlOptions;
+      expect(callOptions?.chatButton).toBe(chatEnabled);
+      expect(callOptions?.screenShareButton).toBe(screenShareEnabled);
+
+      const icons = composite.props().icons as CallWithChatCompositeIcons;
+      expect(icons.LobbyScreenWaitingToBeAdmitted).toBe(logoUrl);
+      expect(icons.LobbyScreenConnectingToCall).toBe(logoUrl);
+
+      const locale = composite.props().locale as CompositeLocale;
+      expect(locale.strings.call.lobbyScreenWaitingToBeAdmittedTitle).toBe(lobbyTitle);
+      expect(locale.strings.call.lobbyScreenWaitingToBeAdmittedMoreDetails).toBe(lobbySubtitle);
+    }
+  );
 
   it('should render CallWithChatComposite when renderPostCall is false', async () => {
     (createAzureCommunicationCallWithChatAdapterFromClients as jest.Mock).mockImplementationOnce(() =>
@@ -150,6 +212,7 @@ describe('TeamsMeetingExperience', () => {
         waitingSubtitle={waitingSubtitle}
         logoUrl={logoUrl}
         chatEnabled={true}
+        screenShareEnabled={true}
         postCall={mockPostCall}
         onDisplayError={jest.fn()}
       />
@@ -183,6 +246,7 @@ describe('TeamsMeetingExperience', () => {
         waitingSubtitle={waitingSubtitle}
         logoUrl={logoUrl}
         chatEnabled={true}
+        screenShareEnabled={true}
         postCall={undefined}
         onDisplayError={jest.fn()}
       />
@@ -218,6 +282,7 @@ describe('TeamsMeetingExperience', () => {
         waitingSubtitle={waitingSubtitle}
         logoUrl={logoUrl}
         chatEnabled={true}
+        screenShareEnabled={true}
         postCall={mockPostCall}
         onDisplayError={jest.fn()}
       />

--- a/client/src/components/teams/TeamsMeetingExperience.test.tsx
+++ b/client/src/components/teams/TeamsMeetingExperience.test.tsx
@@ -185,10 +185,10 @@ describe('TeamsMeetingExperience', () => {
       expect(callOptions?.screenShareButton).toBe(screenShareEnabled);
 
       const lobbyScreenWaitingToBeAdmitted = composite.props().icons?.LobbyScreenWaitingToBeAdmitted;
-      expect(lobbyScreenWaitingToBeAdmitted?.props().src).toBe(logoUrl);
+      expect(lobbyScreenWaitingToBeAdmitted?.props.src).toBe(logoUrl);
 
       const lobbyScreenConnectingToCall = composite.props().icons?.LobbyScreenConnectingToCall;
-      expect(lobbyScreenConnectingToCall?.props().src).toBe(logoUrl);
+      expect(lobbyScreenConnectingToCall?.props.src).toBe(logoUrl);
 
       const locale = composite.props().locale as CompositeLocale;
       expect(locale.strings.call.lobbyScreenWaitingToBeAdmittedTitle).toBe(lobbyTitle);

--- a/client/src/components/teams/TeamsMeetingExperience.tsx
+++ b/client/src/components/teams/TeamsMeetingExperience.tsx
@@ -33,6 +33,7 @@ export interface TeamsMeetingExperienceProps {
   waitingSubtitle: string;
   logoUrl: string;
   chatEnabled: boolean;
+  screenShareEnabled: boolean;
   postCall: PostCallConfig | undefined;
   onDisplayError(error: any): void;
 }
@@ -40,6 +41,7 @@ export interface TeamsMeetingExperienceProps {
 export const TeamsMeetingExperience = (props: TeamsMeetingExperienceProps): JSX.Element => {
   const {
     chatEnabled,
+    screenShareEnabled,
     displayName,
     endpointUrl,
     fluentTheme,
@@ -120,7 +122,8 @@ export const TeamsMeetingExperience = (props: TeamsMeetingExperienceProps): JSX.
             fluentTheme={fluentTheme}
             options={{
               callControls: {
-                chatButton: chatEnabled
+                chatButton: chatEnabled,
+                screenShareButton: screenShareEnabled
               }
             }}
             locale={{


### PR DESCRIPTION
# What

Pass the screenShareEnabled config to the CallWithChatComposite

# Why

Currently, the screen share button is not being toggled

# How Tested

Enabled:
![screenshare-enabled](https://user-images.githubusercontent.com/43504546/208539347-16eca8fb-f70f-4b53-920f-1135cb8ebd10.png)

Disabled:
![screenshare-disabled](https://user-images.githubusercontent.com/43504546/208539370-c9983609-977c-4ea9-9cac-f20fc6b2226e.png)

# Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) documentation.

**Does this PR contain ARM Template changes?**
<!--- If the PR has ARM Template changes check the boxes that apply. -->

- [ ] I have verified deploying using the ARM Template
- [ ] I have tested the deployed app end to end

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->
