### PR TITLE
Add permissions property to publish-release-artifacts.yml

### DIFF
--- a/.github/workflows/publish-release-artifacts.yml
+++ b/.github/workflows/publish-release-artifacts.yml
@@ -15,6 +15,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     name: Publish Release
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Use Node.js v20.17.x
         uses: actions/setup-node@v3
@@ -68,6 +71,8 @@ jobs:
         run: |
           git tag ${{ steps.version.outputs.newProjectVersion }}
           git push --tags
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Create a new Release and publish artifacts
       - name: Upload Release


### PR DESCRIPTION
# What
Add permissions property to publish-release-artifacts.yml so that github bot is able to push tags

# Why
To avoid errors like the shown the following failed run when pushing tags:
https://github.com/Azure-Samples/communication-services-virtual-visits-js/actions/runs/12838635528/job/35804585065

# How Tested
Confirmed to work in this run of the workflow:
https://github.com/Azure-Samples/communication-services-virtual-visits-js/actions/runs/12839133594

# Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) documentation.

**Does this PR contain ARM Template changes?**
<!--- If the PR has ARM Template changes check the boxes that apply. -->

- [ ] I have verified deploying using the ARM Template
- [ ] I have tested the deployed app end to end

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->
